### PR TITLE
Updated transition_model.rb template to include serialize :metadata

### DIFF
--- a/lib/generators/statesman/templates/transition_model.rb.erb
+++ b/lib/generators/statesman/templates/transition_model.rb.erb
@@ -1,4 +1,5 @@
 class <%= klass %> < ActiveRecord::Base
   attr_accessible :to_state, :metadata, :sort_key
   belongs_to :<%= parent.underscore %>, inverse_of: :<%= table_name %>
+  serialize :metadata
 end


### PR DESCRIPTION
A small tweak that'll stop it borking when using the ActiveRecord adapter.
