### PR TITLE
Add after_initialize to Statesman::Machine

### DIFF
--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -145,6 +145,7 @@ module Statesman
       @transition_class = options[:transition_class]
       @storage_adapter = Statesman.storage_adapter.new(
                                             @transition_class, object, self)
+      send(:after_initialize) if respond_to? :after_initialize
     end
 
     def current_state

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -206,6 +206,16 @@ describe Statesman::Machine do
     end
   end
 
+  describe "#after_initialize" do
+    it "is called after initialize" do
+      machine.class_eval do
+        def after_initialize; end
+      end
+      expect_any_instance_of(machine).to receive :after_initialize
+      machine.new(my_model)
+    end
+  end
+
   describe "#current_state" do
     before do
       machine.class_eval do


### PR DESCRIPTION
Its pretty hard to overwrite `initialize` when it is on a mixin (unless you do something crazy like [this](http://pivotallabs.com/redefine-a-method-from-a-module-like-a-gentleman/)).
