### PR TITLE
Favour eager loaded transitions.

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -33,11 +33,15 @@ module Statesman
       end
 
       def history
-        transitions_for_parent.order(:sort_key)
+        if transitions_for_parent.loaded?
+          transitions_for_parent.sort_by(&:sort_key)
+        else
+          transitions_for_parent.order(:sort_key)
+        end
       end
 
       def last
-        @last_transition ||= transitions_for_parent.order(:sort_key).last
+        @last_transition ||= history.last
       end
 
       private

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -35,9 +35,12 @@ describe Statesman::Adapters::ActiveRecord do
       described_class.new(MyActiveRecordModelTransition, model, observer)
     end
 
+    before do
+      adapter.create(:x, :y)
+    end
+
     context "with a previously looked up transition" do
       before do
-        adapter.create(:x, :y)
         adapter.last
       end
 
@@ -52,6 +55,18 @@ describe Statesman::Adapters::ActiveRecord do
         it "retrieves the new transition from the database" do
           expect(adapter.last.to_state).to eq("z")
         end
+      end
+    end
+
+    context "with a pre-fetched transition history" do
+      before do
+        # inspect the transitions to coerce a [pre-]load
+        model.my_active_record_model_transitions.inspect
+      end
+
+      it "doesn't query the database" do
+        MyActiveRecordModelTransition.should_not_receive(:connection)
+        expect(adapter.last.to_state).to eq("y")
       end
     end
   end


### PR DESCRIPTION
Avoid hits on an RDMBS if the associated transitions have already been loaded. Allows for avoidance of N+1 queries on a collection of objects when calculating, for example, the `#current_state`, by favouring pre-fetched data (e.g. `default_scope { eager_load :order_transitions }`).
