### PR TITLE
Allow library to coexist with Squeel.

### DIFF
--- a/lib/statesman/adapters/active_record_model.rb
+++ b/lib/statesman/adapters/active_record_model.rb
@@ -9,14 +9,14 @@ module Statesman
         def in_state(*states)
           joins(transition_name)
             .joins(transition_join)
-            .where("#{transition_name}.to_state" => states)
+            .where("#{transition_name}.to_state" => states.map(&:to_s))
             .where("transition2.id" => nil)
         end
 
         def not_in_state(*states)
           joins(transition_name)
             .joins(transition_join)
-            .where("#{transition_name}.to_state NOT IN (?)", states)
+            .where("#{transition_name}.to_state NOT IN (?)", states.map(&:to_s))
             .where("transition2.id" => nil)
         end
 


### PR DESCRIPTION
Scope query construction gets in a pickle if [Squeel](https://github.com/activerecord-hackery/squeel) is an included gem in a project:

``` ruby
Order.in_state(:cancelled)
  #=> ...WHERE "order_transitions"."to_state" IN ("orders"."cancelled")
```

(Should be: `IN ('cancelled')`.)

Explicitly cast scope arguments to strings to avoid symbols being interpreted as references to columns on the driving table.
