### PR TITLE
Allow multiple Storage Adapter for same app

### DIFF
--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -143,8 +143,7 @@ module Statesman
                       })
       @object = object
       @transition_class = options[:transition_class]
-      @storage_adapter = Statesman.storage_adapter.new(
-                                            @transition_class, object, self)
+      @storage_adapter = (options[:storage_adpater_class] || Statesman.storage_adapter).new(@transition_class, object, self)
       send(:after_initialize) if respond_to? :after_initialize
     end
 


### PR DESCRIPTION
- Some times we do not need to persist transitions

Config set default storage but we can not actually change it for specific models.
