### PR TITLE
Avoid firing potentially expensive guard logic when the transition is invalid anyway.

### DIFF
--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -224,15 +224,15 @@ module Statesman
       from = to_s_or_nil(options[:from])
       to   = to_s_or_nil(options[:to])
 
-      # Call all guards, they raise exceptions if they fail
-      guards_for(from: from, to: to).each do |guard|
-        guard.call(@object, last_transition, options[:metadata])
-      end
-
       successors = self.class.successors[from] || []
       unless successors.include?(to)
         raise TransitionFailedError,
               "Cannot transition from '#{from}' to '#{to}'"
+      end
+
+      # Call all guards, they raise exceptions if they fail
+      guards_for(from: from, to: to).each do |guard|
+        guard.call(@object, last_transition, options[:metadata])
       end
     end
 

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -295,7 +295,9 @@ describe Statesman::Machine do
       machine.class_eval do
         state :x, initial: true
         state :y
+        state :z
         transition from: :x, to: :y
+        transition from: :y, to: :z
       end
     end
 
@@ -312,6 +314,17 @@ describe Statesman::Machine do
         before { instance.transition_to!(:y) }
         let(:new_state) { :y }
         it { should be_false }
+      end
+
+      context "and is guarded" do
+        let(:guard_cb) { -> { false } }
+        let(:new_state) { :z }
+        before { machine.guard_transition(to: new_state, &guard_cb) }
+
+        it "does not fire guard" do
+          guard_cb.should_not_receive(:call)
+          should be_false
+        end
       end
     end
 


### PR DESCRIPTION
Execute guard callbacks only if the machine's transition rules dictate that the transition is allowed.
