### PR TITLE
Generate shorter index names so as not to fail on PostgreSQL or MySQL (or others?) with long table names

### DIFF
--- a/lib/generators/statesman/active_record_transition_generator.rb
+++ b/lib/generators/statesman/active_record_transition_generator.rb
@@ -33,6 +33,10 @@ module Statesman
       klass.underscore.pluralize
     end
 
+    def index_name(index_id)
+      "index_#{table_name}_#{index_id}"
+    end
+
     def parent_id
       parent.underscore + "_id"
     end

--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -8,7 +8,7 @@ class Create<%= klass.pluralize %> < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :<%= table_name %>, :<%= parent_id %>
-    add_index :<%= table_name %>, [:sort_key, :<%= parent_id %>], unique: true
+    add_index :<%= table_name %>, :<%= parent_id %>, name: "<%= index_name :parent %>"
+    add_index :<%= table_name %>, [:sort_key, :<%= parent_id %>], unique: true, name: "<%= index_name :sort_parent  %>"
   end
 end


### PR DESCRIPTION
I don't see any tests for the generators (I could be blind), so... hope this works!

Should fix #48