### PR TITLE
New transition visible for all after callbacks

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -24,6 +24,7 @@ module Statesman
         ::ActiveRecord::Base.transaction do
           @observer.execute(:before, from, to, transition)
           transition.save!
+          @last_transition = transition
           @observer.execute(:after, from, to, transition)
           @last_transition = nil
         end

--- a/lib/statesman/adapters/mongoid.rb
+++ b/lib/statesman/adapters/mongoid.rb
@@ -22,6 +22,7 @@ module Statesman
 
         @observer.execute(:before, from, to, transition)
         transition.save!
+        @last_transition = transition
         @observer.execute(:after, from, to, transition)
         @observer.execute(:after_commit, from, to, transition)
         @last_transition = nil

--- a/spec/statesman/adapters/shared_examples.rb
+++ b/spec/statesman/adapters/shared_examples.rb
@@ -29,6 +29,7 @@ shared_examples_for "an adapter" do |adapter_class, transition_class|
   describe "#create" do
     let(:from) { :x }
     let(:to) { :y }
+    let(:there) { :z }
     let(:create) { adapter.create(from, to) }
     subject { -> { create } }
 
@@ -70,6 +71,16 @@ shared_examples_for "an adapter" do |adapter_class, transition_class|
           expect(adapter.last).to eq(transition) if phase == :after
         end.once
         adapter.create(from, to)
+      end
+
+      it "exposes the new transition for subsequent transitions" do
+        adapter.create(from, to)
+
+        observer.should_receive(:execute).with do
+            |phase, from_state, to_state, transition|
+          expect(adapter.last).to eq(transition) if phase == :after
+        end.once
+        adapter.create(to, there)
       end
     end
 


### PR DESCRIPTION
There is a bug for 2nd transitions or later ones don't make the latest transition visible.

This affects ActiveRecord and Mongoid and happens because those ORMs cache the queries after they return a non null value.
