### PR TITLE
Support for Postgresql JSON column type

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -7,9 +7,15 @@ module Statesman
       attr_reader :parent_model
 
       def initialize(transition_class, parent_model, observer)
-        unless transition_class.serialized_attributes.include?("metadata")
+        serialized = transition_class.serialized_attributes.include?("metadata")
+        column_type = transition_class.columns_hash['metadata'].sql_type
+        if !serialized && column_type != 'json'
           raise UnserializedMetadataError,
                 "#{transition_class.name}#metadata is not serialized"
+        elsif serialized && column_type == 'json'
+          raise IncompatibleSerializationError,
+                "#{transition_class.name}#metadata column type cannot be json
+                  and serialized simultaneously"
         end
         @transition_class = transition_class
         @parent_model = parent_model

--- a/lib/statesman/exceptions.rb
+++ b/lib/statesman/exceptions.rb
@@ -5,4 +5,5 @@ module Statesman
   class GuardFailedError < StandardError; end
   class TransitionFailedError < StandardError; end
   class UnserializedMetadataError < StandardError; end
+  class IncompatibleSerializationError < StandardError; end
 end

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -18,14 +18,38 @@ describe Statesman::Adapters::ActiveRecord do
   it_behaves_like "an adapter", described_class, MyActiveRecordModelTransition
 
   describe "#initialize" do
-    context "with unserialized metadata" do
-      before { MyActiveRecordModelTransition.stub(serialized_attributes: {}) }
+    context "with unserialized metadata and non json column type" do
+      before do
+        metadata_column = double
+        metadata_column.stub(sql_type: '')
+        MyActiveRecordModelTransition.stub(columns_hash:
+                                           { 'metadata' => metadata_column })
+        MyActiveRecordModelTransition.stub(serialized_attributes: {})
+      end
 
-      it "raises an exception if metadata is not serialized" do
+      it "raises an exception" do
         expect do
           described_class.new(MyActiveRecordModelTransition,
                               MyActiveRecordModel, observer)
         end.to raise_exception(Statesman::UnserializedMetadataError)
+      end
+    end
+
+    context "with serialized metadata and json column type" do
+      before do
+        metadata_column = double
+        metadata_column.stub(sql_type: 'json')
+        MyActiveRecordModelTransition.stub(columns_hash:
+                                           { 'metadata' => metadata_column })
+        MyActiveRecordModelTransition.stub(serialized_attributes:
+                                           { 'metadata' => '' })
+      end
+
+      it "raises an exception" do
+        expect do
+          described_class.new(MyActiveRecordModelTransition,
+                              MyActiveRecordModel, observer)
+        end.to raise_exception(Statesman::IncompatibleSerializationError)
       end
     end
   end


### PR DESCRIPTION
Support for Postgresql's native JSON column type. When using this, the `metadata` column should be `json` type and `include Statesman::Adapters::ActiveRecordTransition` should be removed from the transition model
