### PR TITLE
Add option to automatically retry races

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,15 @@ Initialize a new state machine instance. `my_model` is required. If using the
 ActiveRecord adapter `my_model` should have a `has_many` association with
 `MyTransitionModel`.
 
+#### `Machine.retry_conflicts`
+```ruby
+Machine.retry_conflicts { instance.transition_to(:new_state) }
+```
+Automatically retry the given block if a `TransitionConflictError` is raised.
+If you know you want to retry a transition if it fails due to a race condition
+call it from within this block. Takes an (optional) argument for the maximum
+number of retry attempts (defaults to 1).
+
 ## Instance methods
 
 #### `Machine#current_state`
@@ -245,7 +254,7 @@ model and define a `transition_class` method.
 ```ruby
 class Order < ActiveRecord::Base
   include Statesman::Adapters::ActiveRecordModel
-  
+
   private
 
   def self.transition_class

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -12,6 +12,18 @@ module Statesman
       base.send(:attr_reader, :object)
     end
 
+    # Retry any transitions that fail due to a TransitionConflictError
+    def self.retry_conflicts(max_retries = 1)
+      retry_attempt = 0
+
+      begin
+        yield
+      rescue TransitionConflictError
+        retry_attempt += 1
+        retry_attempt <= max_retries ? retry : raise
+      end
+    end
+
     module ClassMethods
       attr_reader :initial_state
 


### PR DESCRIPTION
When race conditions occur, Statesman raises a TransitionConflictError. The user then needs to handle that error.

In many cases we know up front what we want to do if there's a race: we want to retry the second action and get back the right error for it (or have it succeed). This PR adds a `retry_conflicts` method to `Machine` that allows us to specify that up-front:

``` ruby
Machine.retry_conflicts { instance.transition_to(:new_state) }
```
