### PR TITLE
Avoid repeated SQL lookups for current_state

### DIFF
--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -251,8 +251,9 @@ module Statesman
     end
 
     def available_events
+      state = current_state
       self.class.events.select do |_, transitions|
-        transitions.key?(current_state)
+        transitions.key?(state)
       end.map(&:first)
     end
 


### PR DESCRIPTION
Currently, assuming you're not using memory for persistence, when `available_events` is called multiple identical SQL lookups for `current_state` will be triggered. With a large transitions table this could cause a noticeable delay in execution.

By caching a copy of the `current_state` in a local variable for the method we can avoid performing this lookup more than once.
