### PR TITLE
Allow adding callbacks against multiple to states, and bump rubocop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 .bundle
 .config
 .rspec
-.ruby-version
 .yardoc
 Gemfile.lock
 InstalledFiles

--- a/lib/statesman/callback.rb
+++ b/lib/statesman/callback.rb
@@ -11,8 +11,8 @@ module Statesman
         raise InvalidCallbackError, "No callback passed"
       end
 
-      @from = options[:from]
-      @to = options[:to]
+      @from     = options[:from]
+      @to       = Array(options[:to])
       @callback = options[:callback]
     end
 
@@ -34,19 +34,19 @@ module Statesman
     end
 
     def matches_all_transitions
-      from.nil? && to.nil?
+      from.nil? && to.empty?
     end
 
     def matches_from_state(from, to)
-      (from == self.from  && (to.nil? || self.to.nil?))
+      (from == self.from  && (to.nil? || self.to.empty?))
     end
 
     def matches_to_state(from, to)
-      ((from.nil? || self.from.nil?) && to == self.to)
+      ((from.nil? || self.from.nil?) && self.to.include?(to))
     end
 
     def matches_both_states(from, to)
-      from == self.from && to == self.to
+      from == self.from && self.to.include?(to)
     end
   end
 end

--- a/spec/statesman/callback_spec.rb
+++ b/spec/statesman/callback_spec.rb
@@ -72,12 +72,17 @@ describe Statesman::Callback do
 
     context "with any from value on the callback" do
       let(:callback) do
-        Statesman::Callback.new(to: :y, callback: cb_lambda)
+        Statesman::Callback.new(to: [:y, :z], callback: cb_lambda)
       end
       let(:from) { :x }
 
       context "and an allowed to value" do
         let(:to) { :y }
+        it { is_expected.to be_truthy }
+      end
+
+      context "and another allowed to value" do
+        let(:to) { :z }
         it { is_expected.to be_truthy }
       end
 

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -242,14 +242,14 @@ describe Statesman::Machine do
       end
     end
 
-    shared_examples "adds callbacks" do |num_callbacks|
+    shared_examples "adds callback" do
       it "does not raise" do
         expect { set_callback }.to_not raise_error
       end
 
       it "stores callbacks" do
         expect { set_callback }.to change(
-          machine.callbacks[callback_store], :count).by(num_callbacks)
+          machine.callbacks[callback_store], :count).by(1)
       end
 
       it "stores callback instances" do
@@ -290,22 +290,22 @@ describe Statesman::Machine do
     context "with validate_states" do
       context "from anything" do
         let(:options) { { from: nil, to: :y } }
-        it_behaves_like "adds callbacks", 1
+        it_behaves_like "adds callback"
       end
 
       context "to anything" do
         let(:options) { { from: :x, to: [] } }
-        it_behaves_like "adds callbacks", 1
+        it_behaves_like "adds callback"
       end
 
       context "to several" do
         let(:options) { { from: :x, to: [:y, :z] } }
-        it_behaves_like "adds callbacks", 2
+        it_behaves_like "adds callback"
       end
 
       context "from any to several" do
         let(:options) { { from: nil, to: [:y, :z] } }
-        it_behaves_like "adds callbacks", 2
+        it_behaves_like "adds callback"
       end
     end
   end


### PR DESCRIPTION
Allows options[:to] to be an array in add_callback, as per #80
- if to is nil or [] it adds one callback with to: nil as before
- if to is a string/symbol it adds one callback to that state
- if to is an array it adds callbacks to each of those states.

Also DRYed the specs a bit, with shared examples for add_callback succeeding/failing, and bumped Rubocop to 0.26 as everyone loves new cops.

Kinda hate how `nil` is used to mean "any state", especially as this means `<<`ing in nil if an empty array is used for `to`.

@mrappleton could you review this, as it changes functionality? There's some discussion in #82 which was not against master (apologies).
