### PR TITLE
Add not-null conditions to generated statesman tables

### DIFF
--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -1,10 +1,10 @@
 class Create<%= migration_class_name %> < ActiveRecord::Migration
   def change
     create_table :<%= table_name %> do |t|
-      t.string :to_state
+      t.string :to_state, null: false
       t.text :metadata<%= ", default: \"{}\"" unless mysql? %>
-      t.integer :sort_key
-      t.integer :<%= parent_id %>
+      t.integer :sort_key, null: false
+      t.integer :<%= parent_id %>, null: false
       t.timestamps
     end
 

--- a/lib/generators/statesman/templates/update_migration.rb.erb
+++ b/lib/generators/statesman/templates/update_migration.rb.erb
@@ -1,9 +1,9 @@
 class AddStatesmanTo<%= migration_class_name %> < ActiveRecord::Migration
   def change
-    add_column :<%= table_name %>, :to_state, :string
+    add_column :<%= table_name %>, :to_state, :string, null: false
     add_column :<%= table_name %>, :metadata, :text<%= ", default: \"{}\"" unless mysql? %>
-    add_column :<%= table_name %>, :sort_key, :integer
-    add_column :<%= table_name %>, :<%= parent_id %>, :integer
+    add_column :<%= table_name %>, :sort_key, :integer, null: false
+    add_column :<%= table_name %>, :<%= parent_id %>, :integer, null: false
     add_column :<%= table_name %>, :created_at, :datetime
     add_column :<%= table_name %>, :updated_at, :datetime
 

--- a/spec/generators/statesman/migration_generator_spec.rb
+++ b/spec/generators/statesman/migration_generator_spec.rb
@@ -28,5 +28,6 @@ describe Statesman::MigrationGenerator, type: :generator do
 
     it { is_expected.to contain(/:bacon_transition/) }
     it { is_expected.not_to contain(/:yummy\/bacon/) }
+    it { is_expected.to contain(/null: false/) }
   end
 end


### PR DESCRIPTION
You probably don't want your `to_state`, `sort_key` or `parent_id` to ever be null.
