### PR TITLE
Rename ActiveRecordModel to ActiveRecordQueries

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ class OrderStateMachine
 end
 
 class Order < ActiveRecord::Base
-  include Statesman::Adapters::ActiveRecordModel
+  include Statesman::Adapters::ActiveRecordQueries
 
   has_many :order_transitions
 
@@ -65,6 +65,10 @@ class Order < ActiveRecord::Base
 
   def self.transition_class
     OrderTransition
+  end
+
+  def self.initial_state
+    :pending
   end
 end
 
@@ -335,7 +339,7 @@ model and define `transition_class` and `initial_state` class methods:
 
 ```ruby
 class Order < ActiveRecord::Base
-  include Statesman::Adapters::ActiveRecordModel
+  include Statesman::Adapters::ActiveRecordQueries
 
   private
 
@@ -357,16 +361,6 @@ Returns all models not currently in any of the supplied states. Prior to 1.0 thi
 
 ## Frequently Asked Questions
 
-#### `Model.in_state` does not work before first transition
-
-This is expected. State is modelled as a series of tranisitions so initially where there has been no transition, there is no explict state. At GoCardless we get around this by transitioning immediately after creation:
-
-```ruby
-after_create do
-  state_machine.transition_to! "pending"
-end
-```
-
 #### Storing the state on the model object
 
 If you wish to store the model state on the model directly, you can keep it up to date using an `after_transition` hook:
@@ -377,6 +371,8 @@ after_transition do |model, transition|
   model.save!
 end
 ```
+
+You could also use a calculated column or view in your database.
 
 #### Accessing metadata from the last transition
 

--- a/lib/statesman.rb
+++ b/lib/statesman.rb
@@ -9,8 +9,8 @@ module Statesman
     autoload :ActiveRecord, "statesman/adapters/active_record"
     autoload :ActiveRecordTransition,
              "statesman/adapters/active_record_transition"
-    autoload :ActiveRecordModel,
-             "statesman/adapters/active_record_model"
+    autoload :ActiveRecordQueries,
+             "statesman/adapters/active_record_queries"
     autoload :Mongoid,      "statesman/adapters/mongoid"
     autoload :MongoidTransition,
              "statesman/adapters/mongoid_transition"

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -1,6 +1,6 @@
 module Statesman
   module Adapters
-    module ActiveRecordModel
+    module ActiveRecordQueries
       def self.included(base)
         base.extend(ClassMethods)
       end

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -1,13 +1,13 @@
 require "spec_helper"
 
-describe Statesman::Adapters::ActiveRecordModel do
+describe Statesman::Adapters::ActiveRecordQueries do
   before do
     prepare_model_table
     prepare_transitions_table
   end
 
   before do
-    MyActiveRecordModel.send(:include, Statesman::Adapters::ActiveRecordModel)
+    MyActiveRecordModel.send(:include, Statesman::Adapters::ActiveRecordQueries)
     MyActiveRecordModel.class_eval do
       def self.transition_class
         MyActiveRecordModelTransition


### PR DESCRIPTION
`ActiveRecordModel` doesn't really feel like a great name, when it just provides two convenient queries. Including some `ActiveRecordQueries` is much clearer about what it does.

@alan could you review? @hmarr @harrison @jackfranklin @mrappleton any objections for this to go into 1.0.0.beta2?
