### PR TITLE
Resolving deprecation warnings when using implicit joins

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -9,19 +9,23 @@ module Statesman
         def in_state(*states)
           states = states.map(&:to_s)
 
-          joins(transition1_join)
+          includes(transition_name)
+            .joins(transition1_join)
             .joins(transition2_join)
             .where(state_inclusion_where(states), states)
             .where("transition2.id" => nil)
+            .references(transition_name)
         end
 
         def not_in_state(*states)
           states = states.map(&:to_s)
 
-          joins(transition1_join)
+          includes(transition_name)
+            .joins(transition1_join)
             .joins(transition2_join)
             .where("NOT (#{state_inclusion_where(states)})", states)
             .where("transition2.id" => nil)
+            .references(transition_name)
         end
 
         private


### PR DESCRIPTION
Hi, I was getting a warning on recent versions of rails. 

DEPRECATION WARNING: It looks like you are eager loading table(s) (one of: requests, transition1, transition2, floor) that are referenced in a string SQL snippet.

I looked into the code and noticed that the in_state and the not_in_state scopes do not reference the transition table.  I've added the reference and the include to query and that resolved the deprecation warning I was getting.  I also submitted issue #93 to track a conversation about this.

Since this is not coming up in the specs when run on just the project itself, I am not sure how to add a spec for this.