### PR TITLE
Compare initial state and `.in_state` args as strings, whatever they were originally

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -56,7 +56,7 @@ module Statesman
         end
 
         def state_inclusion_where(states)
-          if initial_state.in?(states)
+          if initial_state.to_s.in?(states.map(&:to_s))
             'transition1.to_state IN (?) OR ' \
             'transition1.to_state IS NULL'
           else

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -14,7 +14,7 @@ describe Statesman::Adapters::ActiveRecordQueries do
       end
 
       def self.initial_state
-        MyStateMachine.initial_state
+        :initial
       end
     end
   end


### PR DESCRIPTION
@jackfranklin could you review? This makes the `.(not_)in_state` methods less brittle to issues like #100 . It is also consistent with the code in `Statesman::Machine`, where we `.to_s` all states to avoid `:symbol != 'symbol'` problems.

@nacengineer sorry this wasn't in here before, this should avoid annoying behaviours like you spotted.
