### PR TITLE
Remove use of deprecated serialized_attributes method

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -77,7 +77,7 @@ module Statesman
       end
 
       def serialized?(transition_class)
-        if ::ActiveRecord::VERSION::MINOR >= 2
+        if ::ActiveRecord.gem_version >= Gem::Version.new('4.2')
           transition_class.columns_hash["metadata"]
             .cast_type.is_a?(::ActiveRecord::Type::Serialized)
         else

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -24,7 +24,7 @@ describe Statesman::Adapters::ActiveRecord do
         allow(metadata_column).to receive_messages(sql_type: '')
         allow(MyActiveRecordModelTransition).to receive_messages(columns_hash:
                                            { 'metadata' => metadata_column })
-        if ActiveRecord::VERSION::MINOR >= 2
+        if ::ActiveRecord.gem_version >= Gem::Version.new('4.2')
           allow(metadata_column).to receive_messages(cast_type: '')
         else
           allow(MyActiveRecordModelTransition)
@@ -46,7 +46,7 @@ describe Statesman::Adapters::ActiveRecord do
         allow(metadata_column).to receive_messages(sql_type: 'json')
         allow(MyActiveRecordModelTransition).to receive_messages(columns_hash:
                                            { 'metadata' => metadata_column })
-        if ActiveRecord::VERSION::MINOR >= 2
+        if ::ActiveRecord.gem_version >= Gem::Version.new('4.2')
           allow(metadata_column)
             .to receive_messages(cast_type: ::ActiveRecord::Type::Serialized)
         else


### PR DESCRIPTION
Fixes https://github.com/gocardless/statesman/issues/90

Puts us in a slightly painful transition period - `::ActiveRecord::Type` isn't defined in Rails 4.1, so we can't use that in all cases.
