### PR TITLE
Default metadata should be an empty hash, not nil

### DIFF
--- a/lib/statesman/adapters/memory_transition.rb
+++ b/lib/statesman/adapters/memory_transition.rb
@@ -7,7 +7,7 @@ module Statesman
       attr_accessor :sort_key
       attr_accessor :metadata
 
-      def initialize(to, sort_key, metadata = nil)
+      def initialize(to, sort_key, metadata = {})
         @created_at = Time.now
         @updated_at = Time.now
         @to_state = to

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -202,7 +202,7 @@ module Statesman
       @storage_adapter.last
     end
 
-    def can_transition_to?(new_state, metadata = nil)
+    def can_transition_to?(new_state, metadata = {})
       validate_transition(from: current_state,
                           to: new_state,
                           metadata: metadata)
@@ -215,7 +215,7 @@ module Statesman
       @storage_adapter.history
     end
 
-    def transition_to!(new_state, metadata = nil)
+    def transition_to!(new_state, metadata = {})
       initial_state = current_state
       new_state = new_state.to_s
 
@@ -228,7 +228,7 @@ module Statesman
       true
     end
 
-    def trigger!(event_name, metadata = nil)
+    def trigger!(event_name, metadata = {})
       transitions = self.class.events.fetch(event_name) do
         raise Statesman::TransitionFailedError,
               "Event #{event_name} not found"
@@ -248,13 +248,13 @@ module Statesman
       callbacks.each { |cb| cb.call(@object, transition) }
     end
 
-    def transition_to(new_state, metadata = nil)
+    def transition_to(new_state, metadata = {})
       self.transition_to!(new_state, metadata)
     rescue TransitionFailedError, GuardFailedError
       false
     end
 
-    def trigger(event_name, metadata = nil)
+    def trigger(event_name, metadata = {})
       self.trigger!(event_name, metadata)
     rescue TransitionFailedError, GuardFailedError
       false

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -527,6 +527,11 @@ describe Statesman::Machine do
         expect(instance.history.first.metadata).to eq(meta)
       end
 
+      it "sets an empty hash as the metadata if not specified" do
+        instance.transition_to!(:y)
+        expect(instance.history.first.metadata).to eq({})
+      end
+
       it "returns true" do
         expect(instance.transition_to!(:y)).to be_truthy
       end
@@ -541,7 +546,7 @@ describe Statesman::Machine do
 
           it "passes the object to the guard" do
             expect(guard_cb).to receive(:call).once
-              .with(my_model, instance.last_transition, nil).and_return(true)
+              .with(my_model, instance.last_transition, {}).and_return(true)
             instance.transition_to!(:y)
           end
         end
@@ -703,6 +708,11 @@ describe Statesman::Machine do
         expect(instance.history.first.metadata).to eq(meta)
       end
 
+      it "sets an empty hash as the metadata if not specified" do
+        instance.trigger!(:event_1)
+        expect(instance.history.first.metadata).to eq({})
+      end
+
       it "returns true" do
         expect(instance.trigger!(:event_1)).to eq(true)
       end
@@ -719,7 +729,7 @@ describe Statesman::Machine do
 
           it "passes the object to the guard" do
             expect(guard_cb).to receive(:call).once
-              .with(my_model, instance.last_transition, nil).and_return(true)
+              .with(my_model, instance.last_transition, {}).and_return(true)
             instance.trigger!(:event_1)
           end
         end


### PR DESCRIPTION
In Rails 4.2 serialized columns will store the `nil`, rather than updating it to an empty hash. No-one wants to check for null values when reading metadata, so let's default to `{}`.
