### PR TITLE
Use reflect_on_association, rather than referring to reflections directly

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -41,7 +41,7 @@ module Statesman
         end
 
         def model_foreign_key
-          reflections[transition_name].foreign_key
+          reflect_on_association(transition_name).foreign_key
         end
 
         def transition1_join


### PR DESCRIPTION
Better to use this than get the entire `reflections` hash. Avoids the recent bug with `reflections` switching to string keys, too.
