### PR TITLE
Fix Rails 4.2 conditional

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -77,7 +77,7 @@ module Statesman
       end
 
       def serialized?(transition_class)
-        if ::ActiveRecord.gem_version >= Gem::Version.new('4.2')
+        if ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0.a')
           transition_class.columns_hash["metadata"]
             .cast_type.is_a?(::ActiveRecord::Type::Serialized)
         else

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -24,7 +24,7 @@ describe Statesman::Adapters::ActiveRecord do
         allow(metadata_column).to receive_messages(sql_type: '')
         allow(MyActiveRecordModelTransition).to receive_messages(columns_hash:
                                            { 'metadata' => metadata_column })
-        if ::ActiveRecord.gem_version >= Gem::Version.new('4.2')
+        if ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0.a')
           allow(metadata_column).to receive_messages(cast_type: '')
         else
           allow(MyActiveRecordModelTransition)
@@ -46,11 +46,15 @@ describe Statesman::Adapters::ActiveRecord do
         allow(metadata_column).to receive_messages(sql_type: 'json')
         allow(MyActiveRecordModelTransition).to receive_messages(columns_hash:
                                            { 'metadata' => metadata_column })
-        if ::ActiveRecord.gem_version >= Gem::Version.new('4.2')
-          allow(metadata_column)
-            .to receive_messages(cast_type: ::ActiveRecord::Type::Serialized)
+        if ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0.a')
+          serialized_type = ::ActiveRecord::Type::Serialized.new(
+            '', ::ActiveRecord::Coders::JSON
+          )
+          expect(metadata_column)
+            .to receive(:cast_type)
+            .and_return(serialized_type)
         else
-          allow(MyActiveRecordModelTransition)
+          expect(MyActiveRecordModelTransition)
             .to receive_messages(serialized_attributes: { 'metadata' => '' })
         end
       end


### PR DESCRIPTION
I made a mistake in #103 which meant that Rails 4.2.0.rc1 was still accessing the deprecated codepath. This PR fixes that mistake, and the spec.
