### PR TITLE
Support for and testing against pre-4.1 Rails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ script:
  - bundle exec rubocop
  - bundle exec rake
 env:
-  - "RAILS_VERSION=4.1.7"
-  - "RAILS_VERSION=4.2.0.rc2"
+  - "RAILS_VERSION=3.2.21"
+  - "RAILS_VERSION=4.0.12"
+  - "RAILS_VERSION=4.1.8"
+  - "RAILS_VERSION=4.2.0"

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -77,7 +77,8 @@ module Statesman
       end
 
       def serialized?(transition_class)
-        if ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0.a')
+        if ::ActiveRecord.respond_to?(:gem_version) &&
+           ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0.a')
           transition_class.columns_hash["metadata"]
             .cast_type.is_a?(::ActiveRecord::Type::Serialized)
         else

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -24,7 +24,8 @@ describe Statesman::Adapters::ActiveRecord do
         allow(metadata_column).to receive_messages(sql_type: '')
         allow(MyActiveRecordModelTransition).to receive_messages(columns_hash:
                                            { 'metadata' => metadata_column })
-        if ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0.a')
+        if ::ActiveRecord.respond_to?(:gem_version) &&
+           ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0.a')
           allow(metadata_column).to receive_messages(cast_type: '')
         else
           allow(MyActiveRecordModelTransition)
@@ -46,7 +47,8 @@ describe Statesman::Adapters::ActiveRecord do
         allow(metadata_column).to receive_messages(sql_type: 'json')
         allow(MyActiveRecordModelTransition).to receive_messages(columns_hash:
                                            { 'metadata' => metadata_column })
-        if ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0.a')
+        if ::ActiveRecord.respond_to?(:gem_version) &&
+           ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0.a')
           serialized_type = ::ActiveRecord::Type::Serialized.new(
             '', ::ActiveRecord::Coders::JSON
           )

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -21,6 +21,10 @@ class MyActiveRecordModel < ActiveRecord::Base
     @state_machine ||= MyStateMachine.new(
       self, transition_class: MyActiveRecordModelTransition)
   end
+
+  def metadata
+    super || {}
+  end
 end
 
 class MyActiveRecordModelTransition < ActiveRecord::Base
@@ -44,7 +48,7 @@ class CreateMyActiveRecordModelTransitionMigration < ActiveRecord::Migration
       t.string  :to_state
       t.integer :my_active_record_model_id
       t.integer :sort_key
-      t.text    :metadata
+      t.text    :metadata, default: '{}'
       t.timestamps(null: false)
     end
 

--- a/statesman.gemspec
+++ b/statesman.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop",       "~> 0.27"
   spec.add_development_dependency "guard-rubocop", "~> 1.2"
   spec.add_development_dependency "sqlite3",       "~> 1.3"
-  spec.add_development_dependency "mongoid",       "~> 4.0"
-  spec.add_development_dependency "activerecord",  "~> 4.1"
+  spec.add_development_dependency "mongoid",       ">= 3.1"
+  spec.add_development_dependency "activerecord",  ">= 3.2"
   spec.add_development_dependency "ammeter",       "~> 1.1"
 end


### PR DESCRIPTION
`ActiveRecord.gem_version` was introduced in 4.1, and it seems to be the only thing stopping us from supporting older Rails versions. Added 3.2 and 4.0 to the build matrix and altered usage of `ActiveRecord.gem_version` to work for pre-4.1. @greysteil could you review? I don't remember there being a specific decision to drop old-Rails support, if there was we should document it instead.