### PR TITLE
Specify null: false on timestamps for Rails 5 readiness

### DIFF
--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -5,7 +5,7 @@ class Create<%= migration_class_name %> < ActiveRecord::Migration
       t.text :metadata<%= ", default: \"{}\"" unless mysql? %>
       t.integer :sort_key, null: false
       t.integer :<%= parent_id %>, null: false
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :<%= table_name %>, :<%= parent_id %>

--- a/lib/generators/statesman/templates/update_migration.rb.erb
+++ b/lib/generators/statesman/templates/update_migration.rb.erb
@@ -4,8 +4,8 @@ class AddStatesmanTo<%= migration_class_name %> < ActiveRecord::Migration
     add_column :<%= table_name %>, :metadata, :text<%= ", default: \"{}\"" unless mysql? %>
     add_column :<%= table_name %>, :sort_key, :integer, null: false
     add_column :<%= table_name %>, :<%= parent_id %>, :integer, null: false
-    add_column :<%= table_name %>, :created_at, :datetime
-    add_column :<%= table_name %>, :updated_at, :datetime
+    add_column :<%= table_name %>, :created_at, :datetime, null: false
+    add_column :<%= table_name %>, :updated_at, :datetime, null: false
 
     add_index :<%= table_name %>, :<%= parent_id %>
     add_index :<%= table_name %>, [:sort_key, :<%= parent_id %>], unique: true


### PR DESCRIPTION
For #119 

@jackfranklin I think timestamps should probably always be `NOT NULL`, otherwise they're a bit pointless.