### PR TITLE
add metadata parameter to allowed_transitions method

### DIFF
--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -192,9 +192,9 @@ module Statesman
       last_action ? last_action.to_state : self.class.initial_state
     end
 
-    def allowed_transitions
+    def allowed_transitions(metadata = {})
       successors_for(current_state).select do |state|
-        can_transition_to?(state)
+        can_transition_to?(state, metadata)
       end
     end
 

--- a/spec/statesman/adapters/shared_examples.rb
+++ b/spec/statesman/adapters/shared_examples.rb
@@ -67,8 +67,7 @@ shared_examples_for "an adapter" do |adapter_class, transition_class|
     context "with after callbacks" do
       it "is called after the state transition" do
         expect(observer).to receive(:execute)
-          .with(:after, anything, anything, anything) {
-            |_phase, _from_state, _to_state, transition|
+          .with(:after, anything, anything, anything) { |_, _, _, transition|
             expect(adapter.last).to eq(transition)
           }.once
         adapter.create(from, to)
@@ -78,8 +77,7 @@ shared_examples_for "an adapter" do |adapter_class, transition_class|
         adapter.create(from, to)
 
         expect(observer).to receive(:execute)
-          .with(:after, anything, anything, anything) {
-            |_phase, _from_state, _to_state, transition|
+          .with(:after, anything, anything, anything) { |_, _, _, transition|
             expect(adapter.last).to eq(transition)
           }.once
         adapter.create(to, there)


### PR DESCRIPTION
This might be useful to check available transitions with guards, like checking valid transitions for the current user role.