### PR TITLE
Add support for inheriting states, initial state, events, etc.

### DIFF
--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -27,6 +27,12 @@ module Statesman
 
     module ClassMethods
       attr_reader :initial_state
+      
+      def inherited subclass
+        [:@states, :@initial_state, :@events, :@successors, :@callbacks].each do |ivar|
+          subclass.instance_variable_set(ivar, instance_variable_get(ivar))
+        end
+      end
 
       def states
         @states ||= []

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -27,9 +27,16 @@ module Statesman
 
     module ClassMethods
       attr_reader :initial_state
-      
-      def inherited subclass
-        [:@states, :@initial_state, :@events, :@successors, :@callbacks].each do |ivar|
+      INHERITABLE_IVARS = [
+        :@states,
+        :@initial_state,
+        :@events,
+        :@successors,
+        :@callbacks
+      ]
+
+      def inherited(subclass)
+        INHERITABLE_IVARS.each do |ivar|
           subclass.instance_variable_set(ivar, instance_variable_get(ivar))
         end
       end


### PR DESCRIPTION
(Note: This is only a preliminary pull request.  I wanted to show the proposed feature and get feedback before spending the time to draw up test cases, etc., but I've tested and used it already in one of my own projects and the basic functionality works.)

# Background

In the Readme, it mentions support for using multiple Statesman machines for a single class.  This is a great feature and one of the things I find most attractive about Statesman, as I think it eases a lot of otherwise complicated guards and checks.

This feature would be easier to implement and DRYer, however, if states, events, etc. could be inherited.  The proposed feature would allow for subclasses to inherit states, events, etc. from their superclass, assuming the superclass includes Statesman::Machine.

# An Example

Let me give a condensed example from the application that gave rise to this.

```ruby
module SubmissionMachine
  class Base
    include Statesman::Machine

    state :draft, initial: true
    state :awaiting_review
    state :complete
  end

  class Student < Base
    transition from: :draft, to: :awaiting_review
  end

  class Instructor < Base
    transition from: :awaiting_review, to: :complete
  end
end

# models/submission.rb

class Submission
  def state_machine current_user=nil
    if current_user == student
       SubmissionMachine::Student.new(self, transition_class: SubmissionTransition)
    elsif current_user == instructor
       SubmissionMachine::Instructor.new(self, transition_class: SubmissionTransition)
    else
      SubmissionMachine::Base.new(self, transition_class: SubmissionTransition)
    end
  end
end
```

Given the above setup, if `current_user` is the student, the submission can transition from draft to awaiting review but not from awaiting review to complete; and if `current_user` is the teacher, the submission can transition from awaiting review to complete but not from draft to awaiting review.

Even if this particular example seems trivial, I think this basic approach opens up a lot of useful design patterns.

# Possible Changes

I think this would be a good feature as is, since I think this is really the expected behavior.  If you want it to be an option, however—maybe you need to drop an `inherit! :states, :events` at the top of your superclass?—that would be easy enough to implement.

Please let me know what you think, and if you like the idea (or even are just interested in the idea) I'll carry forward with test cases, etc.