### PR TITLE
Allow ActiveRecordQueries to accept array as an argument.

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -7,7 +7,7 @@ module Statesman
 
       module ClassMethods
         def in_state(*states)
-          states = states.map(&:to_s)
+          states = states.flatten.map(&:to_s)
 
           joins(transition1_join)
             .joins(transition2_join)
@@ -16,7 +16,7 @@ module Statesman
         end
 
         def not_in_state(*states)
-          states = states.map(&:to_s)
+          states = states.flatten.map(&:to_s)
 
           joins(transition1_join)
             .joins(transition2_join)

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -60,6 +60,13 @@ describe Statesman::Adapters::ActiveRecordQueries do
       it { is_expected.to include initial_state_model }
       it { is_expected.to include returned_to_initial_model }
     end
+
+    context "given an array of states" do
+      subject { MyActiveRecordModel.in_state([:succeeded, :failed]) }
+
+      it { is_expected.to include model }
+      it { is_expected.to include other_model }
+    end
   end
 
   describe ".not_in_state" do
@@ -71,6 +78,14 @@ describe Statesman::Adapters::ActiveRecordQueries do
 
     context "given multiple states" do
       subject { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
+      it do
+        is_expected.to match_array([initial_state_model,
+                                    returned_to_initial_model])
+      end
+    end
+
+    context "given an array of states" do
+      subject { MyActiveRecordModel.not_in_state([:succeeded, :failed]) }
       it do
         is_expected.to match_array([initial_state_model,
                                     returned_to_initial_model])


### PR DESCRIPTION
Hopefully this fits within your guidelines.. 

I am using these query methods with has_scope which forwards an array as an argument to the related query method.

Allows the following usage:

* `.in_state([:succeeded, :failed])`
* `.not_in_state([:succeeded, :failed])`

This matches the behaviour of ActiveRecord::Base#find where `Person.find(1, 2, 6)` or
`Person.find([1, 2, 6])` will return the same result.