### PR TITLE
Support for Unconventional Transition Associations

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,12 @@ And add an association from the parent model:
 
 ```ruby
 class Order < ActiveRecord::Base
-  has_many :order_transitions
+  has_many :transitions, class_name: "OrderTransition"
 
   # Initialize the state machine
   def state_machine
-    @state_machine ||= OrderStateMachine.new(self, transition_class: OrderTransition)
+    @state_machine ||= OrderStateMachine.new(self, transition_class: OrderTransition,
+                                                   association_name: :transitions)
   end
 
   # Optionally delegate some methods
@@ -287,6 +288,29 @@ class Order < ActiveRecord::Base
   include Statesman::Adapters::ActiveRecordQueries
 
   private
+
+  def self.transition_class
+    OrderTransition
+  end
+
+  def self.initial_state
+    OrderStateMachine.initial_state
+  end
+end
+```
+
+If the transition class-name differs from the association name, you will also
+need to define a corresponding `transition_name` class method:
+
+```ruby
+class Order < ActiveRecord::Base
+  has_many :transitions, class_name: "OrderTransition"
+
+  private
+
+  def self.transition_name
+    :transitions
+  end
 
   def self.transition_class
     OrderTransition

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -8,7 +8,7 @@ module Statesman
 
       JSON_COLUMN_TYPES = %w(json jsonb).freeze
 
-      def initialize(transition_class, parent_model, observer)
+      def initialize(transition_class, parent_model, observer, options = {})
         serialized = serialized?(transition_class)
         column_type = transition_class.columns_hash['metadata'].sql_type
         if !serialized && !JSON_COLUMN_TYPES.include?(column_type)
@@ -22,6 +22,8 @@ module Statesman
         @transition_class = transition_class
         @parent_model = parent_model
         @observer = observer
+        @association_name =
+          options[:association_name] || @transition_class.table_name
       end
 
       def create(from, to, metadata = {})
@@ -76,7 +78,7 @@ module Statesman
       end
 
       def transitions_for_parent
-        @parent_model.send(@transition_class.table_name)
+        @parent_model.send(@association_name)
       end
 
       def unset_old_most_recent

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -66,23 +66,31 @@ module Statesman
           transition_class.table_name.to_sym
         end
 
+        def transition_reflection
+          reflect_on_association(transition_name)
+        end
+
         def model_foreign_key
-          reflect_on_association(transition_name).foreign_key
+          transition_reflection.foreign_key
+        end
+
+        def model_table
+          transition_reflection.table_name
         end
 
         def transition1_join
-          "LEFT OUTER JOIN #{transition_name} transition1
+          "LEFT OUTER JOIN #{model_table} transition1
              ON transition1.#{model_foreign_key} = #{table_name}.id"
         end
 
         def transition2_join
-          "LEFT OUTER JOIN #{transition_name} transition2
+          "LEFT OUTER JOIN #{model_table} transition2
              ON transition2.#{model_foreign_key} = #{table_name}.id
              AND transition2.sort_key > transition1.sort_key"
         end
 
         def most_recent_transition_join
-          "LEFT OUTER JOIN #{transition_name} AS last_transition
+          "LEFT OUTER JOIN #{model_table} AS last_transition
              ON #{table_name}.id = last_transition.#{model_foreign_key}
              AND last_transition.most_recent = #{db_true}"
         end

--- a/lib/statesman/adapters/memory.rb
+++ b/lib/statesman/adapters/memory.rb
@@ -9,7 +9,7 @@ module Statesman
 
       # We only accept mode as a parameter to maintain a consistent interface
       # with other adapters which require it.
-      def initialize(transition_class, parent_model, observer)
+      def initialize(transition_class, parent_model, observer, _ = {})
         @history = []
         @transition_class = transition_class
         @parent_model = parent_model

--- a/lib/statesman/adapters/mongoid.rb
+++ b/lib/statesman/adapters/mongoid.rb
@@ -6,7 +6,7 @@ module Statesman
       attr_reader :transition_class
       attr_reader :parent_model
 
-      def initialize(transition_class, parent_model, observer)
+      def initialize(transition_class, parent_model, observer, _ = {})
         @transition_class = transition_class
         @parent_model = parent_model
         @observer = observer

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -183,7 +183,7 @@ module Statesman
       @object = object
       @transition_class = options[:transition_class]
       @storage_adapter = adapter_class(@transition_class).new(
-        @transition_class, object, self)
+        @transition_class, object, self, options)
       send(:after_initialize) if respond_to? :after_initialize
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,12 @@ RSpec.configure do |config|
   end
 
   config.before(:each, active_record: true) do
-    tables = %w(my_active_record_models my_active_record_model_transitions)
+    tables = %w(
+      my_active_record_models
+      my_active_record_model_transitions
+      my_namespace_my_active_record_models
+      my_namespace_my_active_record_model_transitions
+    )
     tables.each do |table_name|
       sql = "DROP TABLE IF EXISTS #{table_name};"
       ActiveRecord::Base.connection.execute(sql)

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -204,4 +204,25 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
       end
     end
   end
+
+  context "with a namespaced model" do
+    before do
+      silence_stream(STDOUT) do
+        CreateNamespacedARModelMigration.migrate(:up)
+        CreateNamespacedARModelTransitionMigration.migrate(:up)
+      end
+    end
+
+    before do
+      MyNamespace::MyActiveRecordModelTransition.serialize(:metadata, JSON)
+    end
+    let(:observer) { double(Statesman::Machine, execute: nil) }
+    let(:model) do
+      MyNamespace::MyActiveRecordModel.create(current_state: :pending)
+    end
+
+    it_behaves_like "an adapter",
+                    described_class, MyNamespace::MyActiveRecordModelTransition,
+                    association_name: :my_active_record_model_transitions
+  end
 end

--- a/spec/statesman/adapters/shared_examples.rb
+++ b/spec/statesman/adapters/shared_examples.rb
@@ -11,9 +11,16 @@ require "spec_helper"
 #   history:          Returns the full transition history
 #   last:             Returns the latest transition history item
 #
-shared_examples_for "an adapter" do |adapter_class, transition_class|
+# rubocop:disable Metrics/LineLength
+# NOTE This line cannot reasonably be shortened.
+shared_examples_for "an adapter" do |adapter_class, transition_class, options = {}|
+  # rubocop:enable Metrics/LineLength
+
   let(:observer) { double(Statesman::Machine, execute: nil) }
-  let(:adapter) { adapter_class.new(transition_class, model, observer) }
+  let(:adapter) do
+    adapter_class.new(transition_class,
+                      model, observer, options)
+  end
 
   describe "#initialize" do
     subject { adapter }

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -316,21 +316,23 @@ describe Statesman::Machine do
     context "transition class" do
       it "sets a default" do
         expect(Statesman.storage_adapter).to receive(:new).once.
-          with(Statesman::Adapters::MemoryTransition, my_model, anything)
+          with(Statesman::Adapters::MemoryTransition,
+               my_model, anything, anything)
         machine.new(my_model)
       end
 
       it "sets the passed class" do
         my_transition_class = Class.new
         expect(Statesman.storage_adapter).to receive(:new).once.
-          with(my_transition_class, my_model, anything)
+          with(my_transition_class, my_model, anything, anything)
         machine.new(my_model, transition_class: my_transition_class)
       end
 
       it "falls back to Memory without transaction_class" do
         allow(Statesman).to receive(:storage_adapter).and_return(Class.new)
         expect(Statesman::Adapters::Memory).to receive(:new).once.
-          with(Statesman::Adapters::MemoryTransition, my_model, anything)
+          with(Statesman::Adapters::MemoryTransition,
+               my_model, anything, anything)
         machine.new(my_model)
       end
     end


### PR DESCRIPTION
This pull request adds support for an `association_name` option when initializing a state-machine. This supports transition model associations where the transition model's table-name doesn't match the association--for example, when models are namespaced.

I left in some rough specs that motivated the change in implementation. They don't provide much value, and I think they can reasonably be removed, but let me know what your preference is.

See #130 for motivation and other details.