### PR TITLE
Add most_recent column to transitions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - Rakefile
     - statesman.gemfile
   Exclude:
-    - vendor/**
+    - vendor/**/*
     - .*/**
 
 StringLiterals:

--- a/README.md
+++ b/README.md
@@ -222,6 +222,13 @@ It is also possible to use the PostgreSQL JSON column if you are using Rails 4. 
 * Remove `include Statesman::Adapters::ActiveRecordTransition` statement from your
   transition model
 
+#### Creating transitions without using `#transition_to` with ActiveRecord
+
+By default, Statesman will include a `most_recent` column on the transitions
+table, and update its value each time `#transition_to` is called. If you create
+transitions manually (for example to backfill for a new state) you will need to
+set the `most_recent` attribute manually.
+
 
 ## Configuration
 
@@ -424,40 +431,6 @@ describe "some callback" do
       }.by(1)
   end
 end
-```
-
-#### Creating models in certain states
-
-Sometimes you'll want to test a guard/transition from one state to another, where the state you want to go from is not the initial state of the model. In this instance you'll need to construct a model instance in the state required. However, if you have strict guards, this can be a pain. One way to get around this in tests is to directly create the transitions in the database, hence avoiding the guards.
-
-We use [FactoryGirl](https://github.com/thoughtbot/factory_girl) for creating our test objects. Given an `Order` model that is backed by Statesman, we can easily set it up to be in a particular state:
-
-```ruby
-factory :order do
-  property "value"
-  ...
-
-  trait :shipped do
-    after(:create) do |order|
-      FactoryGirl.create(:order_transition, :shipped, order: order)
-    end
-  end
-end
-
-factory :order_transition do
-  order
-  ...
-
-  trait :shipped do
-    to_state "shipped"
-  end
-end
-```
-
-This means you can easily create an `Order` in the `shipped` state:
-
-```ruby
-let(:shipped_order) { FactoryGirl.create(:order, :shipped) }
 ```
 
 ---

--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -5,9 +5,11 @@ class Create<%= migration_class_name %> < ActiveRecord::Migration
       t.text :metadata<%= ", default: \"{}\"" unless mysql? %>
       t.integer :sort_key, null: false
       t.integer :<%= parent_id %>, null: false
+      t.boolean :most_recent, null: false
       t.timestamps null: false
     end
 
-    add_index :<%= table_name %>, [:<%= parent_id %>, :sort_key], unique: true, name: "<%= index_name :parent_sort  %>"
+    add_index :<%= table_name %>, [:<%= parent_id %>, :sort_key], unique: true, name: "<%= index_name :parent_sort %>"
+    add_index :<%= table_name %>, [:<%= parent_id %>, :most_recent], unique: true, where: "most_recent", name: "<%= index_name :parent_most_recent %>"
   end
 end

--- a/lib/generators/statesman/templates/update_migration.rb.erb
+++ b/lib/generators/statesman/templates/update_migration.rb.erb
@@ -8,5 +8,6 @@ class AddStatesmanTo<%= migration_class_name %> < ActiveRecord::Migration
     add_column :<%= table_name %>, :updated_at, :datetime, null: false
 
     add_index :<%= table_name %>, [:<%= parent_id %>, :sort_key], unique: true, name: "<%= index_name :parent_sort  %>"
+    add_index :<%= table_name %>, [:<%= parent_id %>, :most_recent], unique: true, where: "most_recent", name: "<%= index_name :parent_most_recent %>"
   end
 end

--- a/lib/generators/statesman/templates/update_migration.rb.erb
+++ b/lib/generators/statesman/templates/update_migration.rb.erb
@@ -4,6 +4,7 @@ class AddStatesmanTo<%= migration_class_name %> < ActiveRecord::Migration
     add_column :<%= table_name %>, :metadata, :text<%= ", default: \"{}\"" unless mysql? %>
     add_column :<%= table_name %>, :sort_key, :integer, null: false
     add_column :<%= table_name %>, :<%= parent_id %>, :integer, null: false
+    add_column :<%= table_name %>, :most_recent, null: false
     add_column :<%= table_name %>, :created_at, :datetime, null: false
     add_column :<%= table_name %>, :updated_at, :datetime, null: false
 

--- a/spec/generators/statesman/migration_generator_spec.rb
+++ b/spec/generators/statesman/migration_generator_spec.rb
@@ -33,5 +33,10 @@ describe Statesman::MigrationGenerator, type: :generator do
       expect(subject).
         to contain("name: \"index_bacon_transitions_parent_sort\"")
     end
+
+    it "names the most_recent index appropriately" do
+      expect(subject).
+        to contain("name: \"index_bacon_transitions_parent_most_recent\"")
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,14 @@ RSpec.configure do |config|
     def prepare_transitions_table
       silence_stream(STDOUT) do
         CreateMyActiveRecordModelTransitionMigration.migrate(:up)
+        MyActiveRecordModelTransition.reset_column_information
+      end
+    end
+
+    def drop_most_recent_column
+      silence_stream(STDOUT) do
+        DropMostRecentColumn.migrate(:up)
+        MyActiveRecordModelTransition.reset_column_information
       end
     end
   end

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -7,6 +7,11 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
   end
 
   before do
+    Statesman.configure { storage_adapter(Statesman::Adapters::ActiveRecord) }
+  end
+  after { Statesman.configure { storage_adapter(Statesman::Adapters::Memory) } }
+
+  before do
     MyActiveRecordModel.send(:include, Statesman::Adapters::ActiveRecordQueries)
     MyActiveRecordModel.class_eval do
       def self.transition_class
@@ -21,13 +26,13 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
 
   let!(:model) do
     model = MyActiveRecordModel.create
-    model.my_active_record_model_transitions.create(to_state: :succeeded)
+    model.state_machine.transition_to(:succeeded)
     model
   end
 
   let!(:other_model) do
     model = MyActiveRecordModel.create
-    model.my_active_record_model_transitions.create(to_state: :failed)
+    model.state_machine.transition_to(:failed)
     model
   end
 
@@ -35,60 +40,119 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
 
   let!(:returned_to_initial_model) do
     model = MyActiveRecordModel.create
-    model.my_active_record_model_transitions.create(to_state: :failed)
-    model.my_active_record_model_transitions.create(to_state: :initial)
+    model.state_machine.transition_to(:failed)
+    model.state_machine.transition_to(:initial)
     model
   end
 
-  describe ".in_state" do
-    context "given a single state" do
-      subject { MyActiveRecordModel.in_state(:succeeded) }
+  context "with a most_recent column" do
+    describe ".in_state" do
+      context "given a single state" do
+        subject { MyActiveRecordModel.in_state(:succeeded) }
 
-      it { is_expected.to include model }
-    end
+        it { is_expected.to include model }
+      end
 
-    context "given multiple states" do
-      subject { MyActiveRecordModel.in_state(:succeeded, :failed) }
+      context "given multiple states" do
+        subject { MyActiveRecordModel.in_state(:succeeded, :failed) }
 
-      it { is_expected.to include model }
-      it { is_expected.to include other_model }
-    end
+        it { is_expected.to include model }
+        it { is_expected.to include other_model }
+      end
 
-    context "given the initial state" do
-      subject { MyActiveRecordModel.in_state(:initial) }
+      context "given the initial state" do
+        subject { MyActiveRecordModel.in_state(:initial) }
 
-      it { is_expected.to include initial_state_model }
-      it { is_expected.to include returned_to_initial_model }
-    end
+        it { is_expected.to include initial_state_model }
+        it { is_expected.to include returned_to_initial_model }
+      end
 
-    context "given an array of states" do
-      subject { MyActiveRecordModel.in_state([:succeeded, :failed]) }
+      context "given an array of states" do
+        subject { MyActiveRecordModel.in_state([:succeeded, :failed]) }
 
-      it { is_expected.to include model }
-      it { is_expected.to include other_model }
-    end
-  end
-
-  describe ".not_in_state" do
-    context "given a single state" do
-      subject { MyActiveRecordModel.not_in_state(:failed) }
-      it { is_expected.to include model }
-      it { is_expected.not_to include other_model }
-    end
-
-    context "given multiple states" do
-      subject { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
-      it do
-        is_expected.to match_array([initial_state_model,
-                                    returned_to_initial_model])
+        it { is_expected.to include model }
+        it { is_expected.to include other_model }
       end
     end
 
-    context "given an array of states" do
-      subject { MyActiveRecordModel.not_in_state([:succeeded, :failed]) }
-      it do
-        is_expected.to match_array([initial_state_model,
-                                    returned_to_initial_model])
+    describe ".not_in_state" do
+      context "given a single state" do
+        subject { MyActiveRecordModel.not_in_state(:failed) }
+        it { is_expected.to include model }
+        it { is_expected.not_to include other_model }
+      end
+
+      context "given multiple states" do
+        subject { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
+        it do
+          is_expected.to match_array([initial_state_model,
+                                      returned_to_initial_model])
+        end
+      end
+
+      context "given an array of states" do
+        subject { MyActiveRecordModel.not_in_state([:succeeded, :failed]) }
+        it do
+          is_expected.to match_array([initial_state_model,
+                                      returned_to_initial_model])
+        end
+      end
+    end
+  end
+
+  context "without a most_recent column" do
+    before { drop_most_recent_column }
+
+    describe ".in_state" do
+      context "given a single state" do
+        subject { MyActiveRecordModel.in_state(:succeeded) }
+
+        it { is_expected.to include model }
+      end
+
+      context "given multiple states" do
+        subject { MyActiveRecordModel.in_state(:succeeded, :failed) }
+
+        it { is_expected.to include model }
+        it { is_expected.to include other_model }
+      end
+
+      context "given the initial state" do
+        subject { MyActiveRecordModel.in_state(:initial) }
+
+        it { is_expected.to include initial_state_model }
+        it { is_expected.to include returned_to_initial_model }
+      end
+
+      context "given an array of states" do
+        subject { MyActiveRecordModel.in_state([:succeeded, :failed]) }
+
+        it { is_expected.to include model }
+        it { is_expected.to include other_model }
+      end
+    end
+
+    describe ".not_in_state" do
+      context "given a single state" do
+        subject { MyActiveRecordModel.not_in_state(:failed) }
+        it { is_expected.to include model }
+        it { is_expected.not_to include other_model }
+      end
+
+      context "given multiple states" do
+        subject { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
+        it do
+          is_expected.to match_array([initial_state_model,
+                                      returned_to_initial_model])
+        end
+      end
+
+      context "given an array of states" do
+        subject { MyActiveRecordModel.not_in_state([:succeeded, :failed]) }
+        it do
+          is_expected.to match_array([initial_state_model,
+                                      returned_to_initial_model])
+        end
       end
     end
   end

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -102,6 +102,30 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
         it { is_expected.to raise_exception(StandardError) }
       end
     end
+
+    context "when the transition_class has a most_recent column" do
+      subject { create }
+
+      context "with no previous transition" do
+        its(:most_recent) { is_expected.to eq(true) }
+      end
+
+      context "with a previous transition" do
+        let!(:previous_transition) { adapter.create(from, to) }
+        its(:most_recent) { is_expected.to eq(true) }
+
+        it "updates the previous transition's most_recent flag" do
+          expect { create }.
+            to change { previous_transition.reload.most_recent }.
+            from(true).to(false)
+        end
+      end
+    end
+
+    context "when the transition_class doesn't have a most_recent column" do
+      before { drop_most_recent_column }
+      it { is_expected.to_not raise_exception }
+    end
   end
 
   describe "#last" do


### PR DESCRIPTION
For discussion. We're using something similar to this at GoCardless to speed up queries on our larger tables.

This PR adds a binary `most_recent` column to the `_transitions` table, and automatically updates that column each time an object is transitioned. This allows `in_state` and `not_in_state` queries to only consider rows where the `most_recent` flag is true, and removes the need to join the transitions table on itself (the current statesman method for identifying the most recent transition).

This PR is fully backwards compatible with the existing statesman query implementation - if a `most_recent` column isn't present it will fall back to the old implementation. To make it really awesome, however, we should include details of how to back-fill old transitions.