### PR TITLE
Run tests against multiple databases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
+language: ruby
 rvm:
   - 2.1
   - 2.0.0
   - 1.9.3
 services: mongodb
+before_script:
+  - mysql -e 'CREATE DATABASE statesman_test;'
+  - psql -c 'CREATE DATABASE statesman_test;' -U postgres
 script:
- - bundle exec rubocop
- - bundle exec rake
+  - bundle exec rubocop
+  - bundle exec rake
 env:
   - "RAILS_VERSION=3.2.21"
   - "RAILS_VERSION=4.0.12"
   - "RAILS_VERSION=4.1.8"
   - "RAILS_VERSION=4.2.0"
+  - "RAILS_VERSION=4.2.0 DATABASE_URL=mysql2://root@localhost/statesman_test"
+  - "RAILS_VERSION=4.2.0 DATABASE_URL=postgres://postgres@localhost/statesman_test"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,12 +26,20 @@ RSpec.configure do |config|
     raise(error)
   end
 
-  config.before(:each) do
-    # Connect to & cleanup test database
-    ActiveRecord::Base.establish_connection(adapter: "sqlite3",
-                                            database: DB.to_s)
+  unless config.exclusion_filter[:active_record]
+    # Connect to the database for activerecord tests
+    db_conn_str = ENV.fetch("DATABASE_URL", "sqlite3::memory:")
+    ActiveRecord::Base.establish_connection(db_conn_str)
 
-    %w(my_models my_model_transitions).each do |table_name|
+    db_adapter = ActiveRecord::Base.connection.adapter_name
+    puts "Running test suite with database #{db_adapter}"
+  else
+    puts "Running test suite without ActiveRecord"
+  end
+
+  config.before(:each, active_record: true) do
+    tables = %w(my_active_record_models my_active_record_model_transitions)
+    tables.each do |table_name|
       sql = "DROP TABLE IF EXISTS #{table_name};"
       ActiveRecord::Base.connection.execute(sql)
     end
@@ -48,6 +56,4 @@ RSpec.configure do |config|
       end
     end
   end
-
-  config.after(:each) { DB.delete if DB.exist? }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,15 +26,15 @@ RSpec.configure do |config|
     raise(error)
   end
 
-  unless config.exclusion_filter[:active_record]
+  if config.exclusion_filter[:active_record]
+    puts "Skipping ActiveRecord tests"
+  else
     # Connect to the database for activerecord tests
     db_conn_str = ENV.fetch("DATABASE_URL", "sqlite3::memory:")
     ActiveRecord::Base.establish_connection(db_conn_str)
 
     db_adapter = ActiveRecord::Base.connection.adapter_name
-    puts "Running test suite with database #{db_adapter}"
-  else
-    puts "Running test suite without ActiveRecord"
+    puts "Running with database adapter '#{db_adapter}'"
   end
 
   config.before(:each, active_record: true) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,8 +30,9 @@ RSpec.configure do |config|
     puts "Skipping ActiveRecord tests"
   else
     # Connect to the database for activerecord tests
-    db_conn_str = ENV.fetch("DATABASE_URL", "sqlite3::memory:")
-    ActiveRecord::Base.establish_connection(db_conn_str)
+    db_conn_spec = ENV["DATABASE_URL"]
+    db_conn_spec ||=  { adapter: "sqlite3", database: ":memory:" }
+    ActiveRecord::Base.establish_connection(db_conn_spec)
 
     db_adapter = ActiveRecord::Base.connection.adapter_name
     puts "Running with database adapter '#{db_adapter}'"

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-describe Statesman::Adapters::ActiveRecordQueries do
+describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
   before do
     prepare_model_table
     prepare_transitions_table

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 require "statesman/adapters/shared_examples"
 require "statesman/exceptions"
 
-describe Statesman::Adapters::ActiveRecord do
+describe Statesman::Adapters::ActiveRecord, active_record: true do
   before do
     prepare_model_table
     prepare_transitions_table

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -46,7 +46,14 @@ class CreateMyActiveRecordModelTransitionMigration < ActiveRecord::Migration
       t.string  :to_state
       t.integer :my_active_record_model_id
       t.integer :sort_key
-      t.text    :metadata, default: '{}'
+
+      # MySQL doesn't allow default values on text fields
+      if ActiveRecord::Base.connection.adapter_name == 'Mysql2'
+        t.text :metadata
+      else
+        t.text :metadata, default: '{}'
+      end
+
       t.timestamps(null: false)
     end
 

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,8 +1,6 @@
 require "support/active_record"
 require "json"
 
-DB = Pathname.new("test.sqlite3")
-
 class MyStateMachine
   include Statesman::Machine
 

--- a/statesman.gemspec
+++ b/statesman.gemspec
@@ -28,5 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sqlite3",       "~> 1.3"
   spec.add_development_dependency "mongoid",       ">= 3.1"
   spec.add_development_dependency "activerecord",  ">= 3.2"
+  spec.add_development_dependency "pg",            "~> 0.18"
+  spec.add_development_dependency "mysql2",        "~> 0.3"
   spec.add_development_dependency "ammeter",       "~> 1.1"
 end


### PR DESCRIPTION
- Support for testing against other (non-Sqlite) databases
- Add Postgres and MySQL to the Travis build matrix
