### PR TITLE
Upgrade path for `most_recent` column

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,9 +4,11 @@ AllCops:
   Include:
     - Rakefile
     - statesman.gemfile
+    - lib/tasks/*.rake
   Exclude:
     - vendor/**/*
     - .*/**
+    - spec/fixtures/**/*
 
 StringLiterals:
   Enabled: false

--- a/lib/generators/statesman/add_constraints_to_most_recent_generator.rb
+++ b/lib/generators/statesman/add_constraints_to_most_recent_generator.rb
@@ -1,0 +1,28 @@
+require "rails/generators"
+require "generators/statesman/generator_helpers"
+
+module Statesman
+  class AddConstraintsToMostRecentGenerator < Rails::Generators::Base
+    include Statesman::GeneratorHelpers
+
+    desc "Adds uniqueness and not-null constraints to the most recent column " \
+         "for a statesman transition"
+
+    argument :parent, type: :string, desc: "Your parent model name"
+    argument :klass,  type: :string, desc: "Your transition model name"
+
+    source_root File.expand_path('../templates', __FILE__)
+
+    def create_model_file
+      template("add_constraints_to_most_recent_migration.rb.erb",
+               migration_file_name)
+    end
+
+    private
+
+    def migration_file_name
+      "db/migrate/#{next_migration_number}_"\
+      "add_constraints_to_most_recent_for_#{table_name}.rb"
+    end
+  end
+end

--- a/lib/generators/statesman/add_most_recent_generator.rb
+++ b/lib/generators/statesman/add_most_recent_generator.rb
@@ -1,0 +1,25 @@
+require "rails/generators"
+require "generators/statesman/generator_helpers"
+
+module Statesman
+  class AddMostRecentGenerator < Rails::Generators::Base
+    include Statesman::GeneratorHelpers
+
+    desc "Adds most_recent to a statesman transition model"
+
+    argument :parent, type: :string, desc: "Your parent model name"
+    argument :klass,  type: :string, desc: "Your transition model name"
+
+    source_root File.expand_path('../templates', __FILE__)
+
+    def create_model_file
+      template("add_most_recent_migration.rb.erb", migration_file_name)
+    end
+
+    private
+
+    def migration_file_name
+      "db/migrate/#{next_migration_number}_add_most_recent_to_#{table_name}.rb"
+    end
+  end
+end

--- a/lib/generators/statesman/templates/add_constraints_to_most_recent_migration.rb.erb
+++ b/lib/generators/statesman/templates/add_constraints_to_most_recent_migration.rb.erb
@@ -1,0 +1,13 @@
+class AddConstraintsToMostRecentFor<%= migration_class_name %> < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def up
+    add_index :<%= table_name %>, [:<%= parent_id %>, :most_recent], unique: true, where: "most_recent", name: "index_<%= table_name %>_parent_most_recent", algorithm: :concurrently
+    change_column :<%= table_name %>, :most_recent, :boolean, null: false
+  end
+
+  def down
+    remove_index :<%= table_name %>, name: "index_<%= table_name %>_parent_most_recent"
+    change_column :<%= table_name %>, :most_recent, :boolean, null: true
+  end
+end

--- a/lib/generators/statesman/templates/add_constraints_to_most_recent_migration.rb.erb
+++ b/lib/generators/statesman/templates/add_constraints_to_most_recent_migration.rb.erb
@@ -3,11 +3,11 @@ class AddConstraintsToMostRecentFor<%= migration_class_name %> < ActiveRecord::M
 
   def up
     add_index :<%= table_name %>, [:<%= parent_id %>, :most_recent], unique: true, where: "most_recent", name: "index_<%= table_name %>_parent_most_recent", algorithm: :concurrently
-    change_column :<%= table_name %>, :most_recent, :boolean, null: false
+    change_column_null :<%= table_name %>, :most_recent, false
   end
 
   def down
     remove_index :<%= table_name %>, name: "index_<%= table_name %>_parent_most_recent"
-    change_column :<%= table_name %>, :most_recent, :boolean, null: true
+    change_column_null :<%= table_name %>, :most_recent, true
   end
 end

--- a/lib/generators/statesman/templates/add_most_recent_migration.rb.erb
+++ b/lib/generators/statesman/templates/add_most_recent_migration.rb.erb
@@ -4,6 +4,6 @@ class AddMostRecentTo<%= migration_class_name %> < ActiveRecord::Migration
   end
 
   def down
-    drop_column :<%= table_name %>, :most_recent
+    remove_column :<%= table_name %>, :most_recent
   end
 end

--- a/lib/generators/statesman/templates/add_most_recent_migration.rb.erb
+++ b/lib/generators/statesman/templates/add_most_recent_migration.rb.erb
@@ -1,0 +1,9 @@
+class AddMostRecentTo<%= migration_class_name %> < ActiveRecord::Migration
+  def up
+    add_column :<%= table_name %>, :most_recent, :boolean, null: true
+  end
+
+  def down
+    drop_column :<%= table_name %>, :most_recent
+  end
+end

--- a/lib/statesman.rb
+++ b/lib/statesman.rb
@@ -15,6 +15,7 @@ module Statesman
     autoload :MongoidTransition,
              "statesman/adapters/mongoid_transition"
   end
+  require 'statesman/railtie' if defined?(::Rails::Railtie)
 
   # Example:
   #   Statesman.configure do

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -9,7 +9,7 @@ module Statesman
         def in_state(*states)
           states = states.flatten.map(&:to_s)
 
-          if most_recent_column?
+          if use_most_recent_column?
             in_state_with_most_recent(states)
           else
             in_state_without_most_recent(states)
@@ -19,7 +19,7 @@ module Statesman
         def not_in_state(*states)
           states = states.flatten.map(&:to_s)
 
-          if most_recent_column?
+          if use_most_recent_column?
             not_in_state_with_most_recent(states)
           else
             not_in_state_without_most_recent(states)
@@ -101,8 +101,14 @@ module Statesman
           ::ActiveRecord::Base.connection.quote(true)
         end
 
-        def most_recent_column?
-          transition_class.columns_hash.include?("most_recent")
+        # Only use the most_recent column if it has a unique index guaranteeing
+        # it has good data
+        def use_most_recent_column?
+          ::ActiveRecord::Base.connection.index_exists?(
+            transition_name,
+            [model_foreign_key, :most_recent],
+            unique: true
+          )
         end
       end
     end

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -107,7 +107,8 @@ module Statesman
           ::ActiveRecord::Base.connection.index_exists?(
             transition_name,
             [model_foreign_key, :most_recent],
-            unique: true
+            unique: true,
+            name: "index_#{transition_name}_parent_most_recent"
           )
         end
       end

--- a/lib/statesman/railtie.rb
+++ b/lib/statesman/railtie.rb
@@ -1,0 +1,9 @@
+module Statesman
+  class Railtie < ::Rails::Railtie
+    railtie_name :statesman
+
+    rake_tasks do
+      load "tasks/statesman.rake"
+    end
+  end
+end

--- a/lib/tasks/statesman.rake
+++ b/lib/tasks/statesman.rake
@@ -1,0 +1,73 @@
+namespace :statesman do
+  desc "Set most_recent to false for old transitions and to true for the "\
+       "latest one. Safe to re-run"
+  task :backfill_most_recent, [:parent_model_name] => :environment do |_, args|
+    parent_model_name = args.parent_model_name
+    abort("Parent model name must be specified") unless parent_model_name
+
+    parent_class = parent_model_name.constantize
+    transition_class = parent_class.transition_class
+    parent_fk = "#{parent_model_name.demodulize.underscore}_id"
+
+    total_models = parent_class.count
+    done_models = 0
+    batch_size = 500
+
+    parent_class.find_in_batches(batch_size: batch_size) do |models|
+      # Set historic transitions to have most_recent FALSE
+      #
+      # This selects transitions (initial_t) with a subsequent transition
+      # (subsequent_t), ensuring uniqueness by disallowing intermediate
+      # transitions (intermediate_t), and updates most_recent to be false.
+      ActiveRecord::Base.connection.execute %{
+        UPDATE #{transition_class.table_name}
+        SET most_recent = false
+        FROM
+        (
+            SELECT initial_t.id, subsequent_t.created_at
+            FROM #{transition_class.table_name} initial_t
+            JOIN #{transition_class.table_name} subsequent_t ON
+            (
+                initial_t.#{parent_fk} = subsequent_t.#{parent_fk}
+                AND initial_t.sort_key < subsequent_t.sort_key
+            )
+            LEFT JOIN #{transition_class.table_name} intermediate_t ON
+            (
+                initial_t.#{parent_fk} = intermediate_t.#{parent_fk}
+                AND subsequent_t.sort_key > intermediate_t.sort_key
+                AND intermediate_t.sort_key > initial_t.sort_key
+            )
+            WHERE initial_t.#{parent_fk}
+              IN (#{models.map { |p| "'#{p.id}'" }.join(',')})
+            AND intermediate_t.id is null
+        ) x
+        WHERE #{transition_class.table_name}.id = x.id;
+      }
+
+      # Set current transition's most_recent to TRUE
+      ActiveRecord::Base.connection.execute %{
+        UPDATE #{transition_class.table_name}
+        SET most_recent = true
+        FROM
+        (
+            SELECT initial_t.id, subsequent_t.created_at
+            FROM #{transition_class.table_name} initial_t
+            LEFT JOIN #{transition_class.table_name} subsequent_t ON
+            (
+                initial_t.#{parent_fk} = subsequent_t.#{parent_fk}
+                AND initial_t.sort_key < subsequent_t.sort_key
+            )
+            WHERE initial_t.#{parent_fk}
+              IN (#{models.map { |p| "'#{p.id}'" }.join(',')})
+            AND subsequent_t.id is null
+        ) x
+        WHERE #{transition_class.table_name}.id = x.id
+      }
+
+      done_models += batch_size
+      puts "Updated #{transition_class.name.pluralize} for "\
+           "#{[done_models, total_models].min}/#{total_models} "\
+           "#{parent_model_name.pluralize}"
+    end
+  end
+end

--- a/lib/tasks/statesman.rake
+++ b/lib/tasks/statesman.rake
@@ -16,9 +16,11 @@ namespace :statesman do
     parent_class.find_in_batches(batch_size: batch_size) do |models|
       # Set historic transitions to have most_recent FALSE
       #
-      # This selects transitions (initial_t) with a subsequent transition
-      # (subsequent_t), ensuring uniqueness by disallowing intermediate
-      # transitions (intermediate_t), and updates most_recent to be false.
+      # The LEFT JOIN eliminates duplicate entries from the first join,
+      # for example, in:
+      #   initial_t.sort_key = 10, subsequent_t.sort_key = 20
+      #   initial_t.sort_key = 10, subsequent_t.sort_key = 30
+      # it would eliminate the second row.
       ActiveRecord::Base.connection.execute %{
         UPDATE #{transition_class.table_name}
         SET most_recent = false

--- a/spec/fixtures/add_constraints_to_most_recent_for_bacon_transitions.rb
+++ b/spec/fixtures/add_constraints_to_most_recent_for_bacon_transitions.rb
@@ -1,0 +1,13 @@
+class AddConstraintsToMostRecentForBaconTransitions < ActiveRecord::Migration
+  disable_ddl_transaction!
+
+  def up
+    add_index :bacon_transitions, [:bacon_id, :most_recent], unique: true, where: "most_recent", name: "index_bacon_transitions_parent_most_recent", algorithm: :concurrently
+    change_column :bacon_transitions, :most_recent, :boolean, null: false
+  end
+
+  def down
+    remove_index :bacon_transitions, name: "index_bacon_transitions_parent_most_recent"
+    change_column :bacon_transitions, :most_recent, :boolean, null: true
+  end
+end

--- a/spec/fixtures/add_constraints_to_most_recent_for_bacon_transitions.rb
+++ b/spec/fixtures/add_constraints_to_most_recent_for_bacon_transitions.rb
@@ -3,11 +3,11 @@ class AddConstraintsToMostRecentForBaconTransitions < ActiveRecord::Migration
 
   def up
     add_index :bacon_transitions, [:bacon_id, :most_recent], unique: true, where: "most_recent", name: "index_bacon_transitions_parent_most_recent", algorithm: :concurrently
-    change_column :bacon_transitions, :most_recent, :boolean, null: false
+    change_column_null :bacon_transitions, :most_recent, false
   end
 
   def down
     remove_index :bacon_transitions, name: "index_bacon_transitions_parent_most_recent"
-    change_column :bacon_transitions, :most_recent, :boolean, null: true
+    change_column_null :bacon_transitions, :most_recent, true
   end
 end

--- a/spec/fixtures/add_most_recent_to_bacon_transitions.rb
+++ b/spec/fixtures/add_most_recent_to_bacon_transitions.rb
@@ -1,0 +1,9 @@
+class AddMostRecentToBaconTransitions < ActiveRecord::Migration
+  def up
+    add_column :bacon_transitions, :most_recent, :boolean, null: true
+  end
+
+  def down
+    drop_column :bacon_transitions, :most_recent
+  end
+end

--- a/spec/fixtures/add_most_recent_to_bacon_transitions.rb
+++ b/spec/fixtures/add_most_recent_to_bacon_transitions.rb
@@ -4,6 +4,6 @@ class AddMostRecentToBaconTransitions < ActiveRecord::Migration
   end
 
   def down
-    drop_column :bacon_transitions, :most_recent
+    remove_column :bacon_transitions, :most_recent
   end
 end

--- a/spec/generators/statesman/add_constraints_to_most_recent_generator_spec.rb
+++ b/spec/generators/statesman/add_constraints_to_most_recent_generator_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+require "support/generators_shared_examples"
+require "generators/statesman/add_constraints_to_most_recent_generator"
+
+describe Statesman::AddConstraintsToMostRecentGenerator, type: :generator do
+  it_behaves_like "a generator" do
+    let(:migration_name) do
+      'db/migrate/add_constraints_to_most_recent_for_bacon_transitions.rb'
+    end
+  end
+
+  describe "the migration contains the correct words" do
+    let(:migration_number) { '5678309' }
+
+    let(:mock_time) do
+      double('Time', utc: double('UTCTime', strftime: migration_number))
+    end
+
+    subject(:migration_file) do
+      file("db/migrate/#{migration_number}_"\
+           "add_constraints_to_most_recent_for_bacon_transitions.rb")
+    end
+
+    let(:fixture_file) do
+      File.read("spec/fixtures/add_constraints_to_most_recent_for_"\
+                "bacon_transitions.rb")
+    end
+
+    before do
+      allow(Time).to receive(:now).and_return(mock_time)
+      run_generator %w(Bacon BaconTransition)
+    end
+
+    it "matches the fixture" do
+      expect(migration_file).to contain(fixture_file)
+    end
+  end
+end

--- a/spec/generators/statesman/add_most_recent_generator_spec.rb
+++ b/spec/generators/statesman/add_most_recent_generator_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+require "support/generators_shared_examples"
+require "generators/statesman/add_most_recent_generator"
+
+describe Statesman::AddMostRecentGenerator, type: :generator do
+  it_behaves_like "a generator" do
+    let(:migration_name) do
+      'db/migrate/add_most_recent_to_bacon_transitions.rb'
+    end
+  end
+
+  describe "the migration" do
+    let(:migration_number) { '5678309' }
+
+    let(:mock_time) do
+      double('Time', utc: double('UTCTime', strftime: migration_number))
+    end
+
+    subject(:migration_file) do
+      file("db/migrate/#{migration_number}_"\
+           "add_most_recent_to_bacon_transitions.rb")
+    end
+
+    let(:fixture_file) do
+      File.read("spec/fixtures/add_most_recent_to_bacon_transitions.rb")
+    end
+
+    before { allow(Time).to receive(:now).and_return(mock_time) }
+    before { run_generator %w(Bacon BaconTransition) }
+
+    it "matches the fixture" do
+      expect(migration_file).to contain(fixture_file)
+    end
+  end
+end

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -51,6 +51,8 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
         subject { MyActiveRecordModel.in_state(:succeeded) }
 
         it { is_expected.to include model }
+        it { is_expected.not_to include other_model }
+        its(:to_sql) { is_expected.to include('most_recent') }
       end
 
       context "given multiple states" do
@@ -80,6 +82,7 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
         subject { MyActiveRecordModel.not_in_state(:failed) }
         it { is_expected.to include model }
         it { is_expected.not_to include other_model }
+        its(:to_sql) { is_expected.to include('most_recent') }
       end
 
       context "given multiple states" do

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -68,14 +68,17 @@ class CreateMyActiveRecordModelTransitionMigration < ActiveRecord::Migration
     add_index :my_active_record_model_transitions,
               [:my_active_record_model_id, :most_recent],
               unique: true, where: "most_recent",
-              name: "most_recent_index"
+              name: "index_my_active_record_model_transitions_"\
+                    "parent_most_recent"
   end
 end
 # rubocop:enable MethodLength
 
 class DropMostRecentColumn < ActiveRecord::Migration
   def change
-    remove_index  :my_active_record_model_transitions, name: :most_recent_index
+    remove_index :my_active_record_model_transitions,
+                 name: "index_my_active_record_model_transitions_"\
+                       "parent_most_recent"
     remove_column :my_active_record_model_transitions, :most_recent
   end
 end


### PR DESCRIPTION
Adds two migrations and a rake task to help with adding most_recent column to an existing statesman transition model.

The first migration is generated with `rails g statesman:add_most_recent`. It adds the most_recent column which will be used for writes when transitioning.

The rake task can be run with `rake statesman:backfill_most_recent[ModelName]` and backfills the most_recent column.

The final migration is generated with `rails g statesman:add_constraints_to_most_recent`. It adds a not-null constraint and a unique partial index which ensure each transition sequence can only have one "most recent" transition.

@hmarr Work in progress but would be good to get your eyes on it?

@isaacseymour FYI