### PR TITLE
Unset most_recent *before* invoking before hooks

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -62,8 +62,8 @@ module Statesman
         transition = transitions_for_parent.build(transition_attributes)
 
         ::ActiveRecord::Base.transaction do
-          @observer.execute(:before, from, to, transition)
           unset_old_most_recent
+          @observer.execute(:before, from, to, transition)
           transition.save!
           @last_transition = transition
           @observer.execute(:after, from, to, transition)

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -119,6 +119,20 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
             to change { previous_transition.reload.most_recent }.
             from(true).to(false)
         end
+
+        context "and the parent model is updated in a callback" do
+          before do
+            allow(observer).to receive(:execute) do |phase|
+              if phase == :before
+                model.update_attributes!(current_state: :ready)
+              end
+            end
+          end
+
+          it "doesn't save the transition too early" do
+            expect { create }.to_not raise_exception
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Updating the parent model in a before hook causes ActiveRecord to save the parent model's associations (which includes the newly-built transition). This means the transition gets saved before we've had a chance to unmark the old most-recent transition.

This fixes that.