### PR TITLE
Implement Allowed events

### DIFF
--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -267,6 +267,18 @@ module Statesman
       end.compact
     end
 
+    def allowed_events
+      state = current_state
+      allowed_events = []
+      self.class.events.map do |event, transitions|
+        if transitions.key?(state) &&
+           can_transition_to?(transitions[state].first)
+          allowed_events << event
+        end
+      end
+      allowed_events
+    end
+
     private
 
     def adapter_class(transition_class)

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -262,9 +262,9 @@ module Statesman
 
     def available_events
       state = current_state
-      self.class.events.select do |_, transitions|
-        transitions.key?(state)
-      end.map(&:first)
+      self.class.events.map do |event, transitions|
+        event if transitions.key?(state)
+      end.compact
     end
 
     private


### PR DESCRIPTION
`allowed_events` is the events counterpart of allowed_transitions. Like `allowed_transitions`, `allowed_events` check whether the applicable guards pass

The `available_events` method do not check if the guards pass. I'm not sure whether there is a legitimate use case for this method but I have not removed it.
