### PR TITLE
Implement can_trigger?(event) and allowed_events

### DIFF
--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -260,11 +260,23 @@ module Statesman
       false
     end
 
+    def can_trigger?(event_name)
+      state = current_state
+      transitions = self.class.events[event_name.to_sym]
+      transitions.key?(state) && can_transition_to?(transitions[state].first)
+    end
+
     def available_events
       state = current_state
       self.class.events.map do |event, transitions|
         event if transitions.key?(state)
       end.compact
+    end
+
+    def allowed_events
+      self.class.events.keys.select do |event_name|
+        can_trigger?(event_name)
+      end
     end
 
     private

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -262,9 +262,9 @@ module Statesman
 
     def available_events
       state = current_state
-      self.class.events.select do |_, transitions|
-        transitions.key?(state)
-      end.map(&:first)
+      self.class.events.map do |event, transitions|
+        event if transitions.key?(state)
+      end.compact
     end
 
     private

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -749,4 +749,113 @@ describe Statesman::Machine do
       expect(instance.available_events).to eq([:event_2, :event_3])
     end
   end
+
+  describe "#can_trigger?" do
+    before do
+      machine.class_eval do
+        state :x, initial: true
+        state :y
+        state :z
+
+        event :event_1 do
+          transition from: :x, to: :y
+        end
+
+        event :event_2 do
+          transition from: :y, to: :z
+        end
+
+        event :event_3 do
+          transition from: :x, to: :z
+        end
+      end
+    end
+
+    let(:instance) { machine.new(my_model) }
+    subject { instance.can_trigger?(event) }
+
+    context "with valid event" do
+      let(:event) { :event_1 }
+      it { is_expected.to be_truthy }
+
+      context "with failing guard" do
+        let(:guard_cb) { ->(*_args) { false } }
+        let(:new_state) { :y }
+        before { machine.guard_transition(to: new_state, &guard_cb) }
+
+        it { is_expected.to be_falsey }
+      end
+
+      context "with passing guard" do
+        let(:guard_cb) { ->(*_args) { true } }
+        let(:new_state) { :y }
+        before { machine.guard_transition(to: new_state, &guard_cb) }
+
+        it { is_expected.to be_truthy }
+      end
+    end
+
+    context "with invalid event" do
+      let(:event) { :event_2 }
+      it { is_expected.to be_falsey }
+
+      context "and is guarded" do
+        let(:guard_cb) { -> { false } }
+        let(:new_state) { :z }
+        before { machine.guard_transition(to: new_state, &guard_cb) }
+
+        it "does not fire guard" do
+          expect(guard_cb).not_to receive(:call)
+          is_expected.to be_falsey
+        end
+      end
+    end
+  end
+
+  describe "#allowed_events" do
+    before do
+      machine.class_eval do
+        state :x, initial: true
+        state :y
+        state :z
+
+        event :event_1 do
+          transition from: :x, to: :y
+        end
+
+        event :event_2 do
+          transition from: :y, to: :z
+        end
+
+        event :event_3 do
+          transition from: :x, to: :z
+        end
+      end
+    end
+
+    let(:instance) { machine.new(my_model) }
+    subject { instance.allowed_events }
+
+    context "with multiple possible events" do
+      it { is_expected.to eq([:event_1, :event_3]) }
+    end
+
+    context "with one possible event" do
+      before { instance.trigger!(:event_1) }
+      it { is_expected.to eq([:event_2]) }
+    end
+
+    context "with no possible transitions" do
+      before { instance.trigger!(:event_3) }
+      it { is_expected.to eq([]) }
+    end
+
+    context "with guarded transitions" do
+      let(:guard_cb) { ->(*_args) { false } }
+      let(:new_state) { :z }
+      before { machine.guard_transition(to: new_state, &guard_cb) }
+
+      it { is_expected.to eq([:event_1]) }
+    end
+  end
 end


### PR DESCRIPTION
`can_trigger?(event)` is the events counterpart to `can_transition_to?`

`allowed_events` is the events counterpart of `allowed_transitions`.
Like `allowed_transitions`, `allowed_events` check whether the
applicable guards pass

The `available_events` method do not check if the guards pass. I'm not sure whether there is a legitimate use case for this method and hence I have not removed it.
