### PR TITLE
Nicer errors for including/not including ActiveRecordTransition

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,3 +42,7 @@ SingleSpaceBeforeFirstArg:
 
 DotPosition:
   EnforcedStyle: trailing
+
+# Allow class and message or instance raises
+Style/RaiseArgs:
+  Enabled: false

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -21,12 +21,9 @@ module Statesman
         serialized = serialized?(transition_class)
         column_type = transition_class.columns_hash['metadata'].sql_type
         if !serialized && !JSON_COLUMN_TYPES.include?(column_type)
-          raise UnserializedMetadataError,
-                "#{transition_class.name}#metadata is not serialized"
+          raise UnserializedMetadataError.new(transition_class.name)
         elsif serialized && JSON_COLUMN_TYPES.include?(column_type)
-          raise IncompatibleSerializationError,
-                "#{transition_class.name}#metadata column type cannot be json
-                  and serialized simultaneously"
+          raise IncompatibleSerializationError.new(transition_class.name)
         end
         @transition_class = transition_class
         @parent_model = parent_model

--- a/lib/statesman/exceptions.rb
+++ b/lib/statesman/exceptions.rb
@@ -4,7 +4,34 @@ module Statesman
   class InvalidCallbackError < StandardError; end
   class GuardFailedError < StandardError; end
   class TransitionFailedError < StandardError; end
-  class UnserializedMetadataError < StandardError; end
-  class IncompatibleSerializationError < StandardError; end
   class TransitionConflictError < StandardError; end
+
+  class UnserializedMetadataError < StandardError
+    def initialize(transition_class_name)
+      super(_message(transition_class_name))
+    end
+
+    private
+
+    def _message(transition_class_name)
+      "#{transition_class_name}#metadata is not serialized. If you " \
+      "are using a non-json column type, you should `include " \
+      "Statesman::Adapters::ActiveRecordTransition`"
+    end
+  end
+
+  class IncompatibleSerializationError < StandardError
+    def initialize(transition_class_name)
+      super(_message(transition_class_name))
+    end
+
+    private
+
+    def _message(transition_class_name)
+      "#{transition_class_name}#metadata column type cannot be json " \
+      "and serialized simultaneously. If you are using a json " \
+      "column type, it is not necessary to `include " \
+      "Statesman::Adapters::ActiveRecordTransition`"
+    end
+  end
 end


### PR DESCRIPTION
The solution is always to start/stop `include Statesman::Adapters::ActiveRecordTransition`-ing. So we should probably mention that. Resolves #164