### PR TITLE
Rake backfill_most_recent task is now db-agnostic.

### DIFF
--- a/lib/tasks/statesman.rake
+++ b/lib/tasks/statesman.rake
@@ -25,24 +25,26 @@ namespace :statesman do
         end
 
         # Set current transition's most_recent to TRUE
-        ActiveRecord::Base.connection.execute %{
-          UPDATE #{transition_class.table_name}
-          SET most_recent = true
-          FROM
-          (
-            SELECT initial_t.id, subsequent_t.created_at
-            FROM #{transition_class.table_name} initial_t
-            LEFT JOIN #{transition_class.table_name} subsequent_t ON
-            (
-                initial_t.#{parent_fk} = subsequent_t.#{parent_fk}
-                AND initial_t.sort_key < subsequent_t.sort_key
-            )
-            WHERE initial_t.#{parent_fk}
-              IN (#{models.map { |p| "'#{p.id}'" }.join(',')})
-            AND subsequent_t.id IS NULL
-          ) x
-          WHERE #{transition_class.table_name}.id = x.id
-        }
+        initial_t = transition_class.arel_table
+        subsequent_t = initial_t.alias
+
+        later_row_for_same_parent = initial_t[parent_fk].
+                                    eq(subsequent_t[parent_fk]).
+                                    and(initial_t[:sort_key].
+                                    lt(subsequent_t[:sort_key]))
+
+        no_later_row = subsequent_t[:id].eq(nil)
+        in_current_parent_batch = initial_t[parent_fk].in(models.map(&:id))
+
+        latest_ids_query = initial_t.join(subsequent_t, Arel::Nodes::OuterJoin).
+                           on(later_row_for_same_parent).
+                           where(no_later_row.and(in_current_parent_batch)).
+                           project(initial_t[:id]).to_sql
+
+        latest_ids = transition_class.find_by_sql(latest_ids_query).
+                     to_a.collect(&:id)
+
+        transition_class.where(id: latest_ids).update_all(most_recent: true)
       end
 
       done_models += batch_size


### PR DESCRIPTION
By virtue of using AREL instead of db-specific (PostgreSQL) SQL.

Fixes #168