### PR TITLE
Name the joined transitions in ActiveRecordQueries

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,8 @@ RSpec.configure do |config|
       my_active_record_model_transitions
       my_namespace_my_active_record_models
       my_namespace_my_active_record_model_transitions
+      other_active_record_models
+      other_active_record_model_transitions
     )
     tables.each do |table_name|
       sql = "DROP TABLE IF EXISTS #{table_name};"
@@ -75,5 +77,20 @@ RSpec.configure do |config|
         MyActiveRecordModelTransition.reset_column_information
       end
     end
+
+    def prepare_other_model_table
+      silence_stream(STDOUT) do
+        CreateOtherActiveRecordModelMigration.migrate(:up)
+      end
+    end
+
+    def prepare_other_transitions_table
+      silence_stream(STDOUT) do
+        CreateOtherActiveRecordModelTransitionMigration.migrate(:up)
+        OtherActiveRecordModelTransition.reset_column_information
+      end
+    end
+
+    MyNamespace::MyActiveRecordModelTransition.serialize(:metadata, JSON)
   end
 end


### PR DESCRIPTION
Allows crazy stuff like:
```ruby
class Model < ActiveRecord::Base
  include Statesman::Adapters::ActiveRecordQueries

  has_many :model_transitions
  has_many :other_models
  ...
end

class OtherModel < ActiveRecord::Base
  include Statesman::Adapters::ActiveRecordQueries

  has_many :other_model_transitions
  belongs_to :model
  ...
end

OtherModel.in_state(:something).joins(:model).merge(Model.in_state(:other_thing))
```
CRAY! :dash: :dancer: :fireworks: 