### PR TITLE
Remove whitespace characters in generator

### DIFF
--- a/lib/generators/statesman/templates/active_record_transition_model.rb.erb
+++ b/lib/generators/statesman/templates/active_record_transition_model.rb.erb
@@ -1,8 +1,8 @@
 class <%= klass %> < ActiveRecord::Base
   include Statesman::Adapters::ActiveRecordTransition
 
-  <% unless rails_4? %>
+<% unless rails_4? %>
   attr_accessible :to_state, :metadata, :sort_key
-  <% end %>
+<% end %>
   belongs_to :<%= parent_name %><%= class_name_option %>, inverse_of: :<%= table_name %>
 end


### PR DESCRIPTION
When running the generator as described in your readme under Rails 4, the resulting file has a line with just two spaces on line 4.