### PR TITLE
Use table_name instead of transition_name

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -127,10 +127,10 @@ module Statesman
         # it has good data
         def use_most_recent_column?
           ::ActiveRecord::Base.connection.index_exists?(
-            transition_name,
+            transition_class.table_name,
             [model_foreign_key, :most_recent],
             unique: true,
-            name: "index_#{transition_name}_parent_most_recent"
+            name: "index_#{transition_class.table_name}_parent_most_recent"
           )
         end
       end

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -15,7 +15,14 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
 
   before do
     MyActiveRecordModel.send(:include, Statesman::Adapters::ActiveRecordQueries)
+    MyActiveRecordModel.send(:has_many,
+                             :transitions,
+                             class_name: 'MyActiveRecordModelTransition')
     MyActiveRecordModel.class_eval do
+      def self.transition_name
+        :transitions
+      end
+
       def self.transition_class
         MyActiveRecordModelTransition
       end
@@ -68,7 +75,7 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
 
         it { is_expected.to include model }
         it { is_expected.not_to include other_model }
-        its(:to_sql) { is_expected.to include('most_recent') }
+        its(:to_sql) { is_expected.to include('most_recent =') }
       end
 
       context "given multiple states" do
@@ -108,7 +115,7 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
         subject { MyActiveRecordModel.not_in_state(:failed) }
         it { is_expected.to include model }
         it { is_expected.not_to include other_model }
-        its(:to_sql) { is_expected.to include('most_recent') }
+        its(:to_sql) { is_expected.to include('most_recent =') }
       end
 
       context "given multiple states" do
@@ -137,6 +144,7 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
         subject { MyActiveRecordModel.in_state(:succeeded) }
 
         it { is_expected.to include model }
+        its(:to_sql) { is_expected.not_to include('most_recent =') }
       end
 
       context "given multiple states" do
@@ -166,6 +174,7 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
         subject { MyActiveRecordModel.not_in_state(:failed) }
         it { is_expected.to include model }
         it { is_expected.not_to include other_model }
+        its(:to_sql) { is_expected.not_to include('most_recent =') }
       end
 
       context "given multiple states" do


### PR DESCRIPTION
Thank you guys for this great gem. I use this on some production apps:)

I would like to fix this bug.

## Error case
https://github.com/gocardless/statesman#model-scopes

> If the transition class-name differs from the association name, you will also need to define a corresponding transition_name class method:

```ruby
class Order < ActiveRecord::Base
  has_many :transitions, class_name: "OrderTransition"

  private

  def self.transition_name
    :transitions
  end

  def self.transition_class
    OrderTransition
  end

  def self.initial_state
    OrderStateMachine.initial_state
  end
end
```

But...
```
[9] pry(main)> Order.in_state(:pending)
ActiveRecord::StatementInvalid: Mysql2::Error: Table 'myapp_development.transitions' doesn't exist: SHOW KEYS FROM `transitions`
from /Users/otsuki.shinsuke/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activerecord-4.2.2/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:299:in `query'
[10] pry(main)> Order.send(:use_most_recent_column?)
ActiveRecord::StatementInvalid: Mysql2::Error: Table 'myapp_development.transitions' doesn't exist: SHOW KEYS FROM `transitions`
from /Users/otsuki.shinsuke/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/activerecord-4.2.2/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:299:in `query'
```