### PR TITLE
Condition most_recent rake task on database supporting partial index

### DIFF
--- a/lib/tasks/statesman.rake
+++ b/lib/tasks/statesman.rake
@@ -15,7 +15,7 @@ namespace :statesman do
 
     parent_class.find_in_batches(batch_size: batch_size) do |models|
       ActiveRecord::Base.transaction do
-        if transition_class.columns_hash['most_recent'].null == false
+        if Statesman::Adapters::ActiveRecord.database_supports_partial_indexes?
           # Set all transitions' most_recent to FALSE
           transition_class.where(parent_fk => models.map(&:id)).
             update_all(most_recent: false)


### PR DESCRIPTION
We only ever want to set `false` values if the database support partial indexes. Otherwise we're going to need to set `nil` values, and use the fact that SQL treats each `null` values as unique.