### PR TITLE
Unset most_recent after before transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ end
 class Order < ActiveRecord::Base
   include Statesman::Adapters::ActiveRecordQueries
 
-  has_many :order_transitions
+  has_many :order_transitions, autosave: false
 
   def state_machine
     @state_machine ||= OrderStateMachine.new(self, transition_class: OrderTransition)
@@ -134,7 +134,7 @@ And add an association from the parent model:
 
 ```ruby
 class Order < ActiveRecord::Base
-  has_many :transitions, class_name: "OrderTransition"
+  has_many :transitions, class_name: "OrderTransition", autosave: false
 
   # Initialize the state machine
   def state_machine
@@ -304,7 +304,7 @@ need to define a corresponding `transition_name` class method:
 
 ```ruby
 class Order < ActiveRecord::Base
-  has_many :transitions, class_name: "OrderTransition"
+  has_many :transitions, class_name: "OrderTransition", autosave: false
 
   private
 

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -67,8 +67,8 @@ module Statesman
         transition = transitions_for_parent.build(transition_attributes)
 
         ::ActiveRecord::Base.transaction do
-          unset_old_most_recent
           @observer.execute(:before, from, to, transition)
+          unset_old_most_recent
           transition.save!
           @last_transition = transition
           @observer.execute(:after, from, to, transition)

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -13,7 +13,7 @@ class MyStateMachine
 end
 
 class MyActiveRecordModel < ActiveRecord::Base
-  has_many :my_active_record_model_transitions
+  has_many :my_active_record_model_transitions, autosave: false
   alias_method :transitions, :my_active_record_model_transitions
 
   def state_machine
@@ -90,7 +90,7 @@ end
 # rubocop:enable MethodLength
 
 class OtherActiveRecordModel < ActiveRecord::Base
-  has_many :other_active_record_model_transitions
+  has_many :other_active_record_model_transitions, autosave: false
   alias_method :transitions, :other_active_record_model_transitions
 
   def state_machine
@@ -178,7 +178,8 @@ end
 module MyNamespace
   class MyActiveRecordModel < ActiveRecord::Base
     has_many :my_active_record_model_transitions,
-             class_name: "MyNamespace::MyActiveRecordModelTransition"
+             class_name: "MyNamespace::MyActiveRecordModelTransition",
+             autosave: false
 
     def self.table_name_prefix
       "my_namespace_"


### PR DESCRIPTION
Currently we're unsetting the `most_recent` column on all a model's transitions **before** the state machine's `before_transition` callbacks have run. That means if any query in those callbacks relies on the model being in ints previous state it will get unexpected result.

This PR changes that to instead unset the `most_recent` column **after** the state machine's `before_transition` callbacks, but before its `after_transition` ones. That's considerably more intuitive, but introduces a potential gotcha: if you attempt to save the parent model during a `before_transition` and you don't have `autosave: false` on the associations you'll get a uniqueness error.

I think that's a fair price to pay for more intuitive behaviour, and it can be mitigated by setting `autosave: false` on the transition association (and this PR updates the readme to suggest that).