### PR TITLE
Require a most_recent column on transition tables

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -62,7 +62,7 @@ module Statesman
                                   sort_key: next_sort_key,
                                   metadata: metadata }
 
-        transition_attributes.merge!(most_recent: true) if most_recent_column?
+        transition_attributes.merge!(most_recent: true)
 
         transition = transitions_for_parent.build(transition_attributes)
 
@@ -83,7 +83,6 @@ module Statesman
       end
 
       def unset_old_most_recent
-        return unless most_recent_column?
         # Check whether the `most_recent` column allows null values. If it
         # doesn't, set old records to `false`, otherwise, set them to `NULL`.
         #
@@ -96,10 +95,6 @@ module Statesman
         else
           transitions_for_parent.update_all(most_recent: nil)
         end
-      end
-
-      def most_recent_column?
-        transition_class.columns_hash.include?("most_recent")
       end
 
       def next_sort_key

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -9,50 +9,19 @@ module Statesman
         def in_state(*states)
           states = states.flatten.map(&:to_s)
 
-          if use_most_recent_column?
-            in_state_with_most_recent(states)
-          else
-            in_state_without_most_recent(states)
-          end
+          joins(most_recent_transition_join).
+            where(states_where(most_recent_transition_alias, states), states)
         end
 
         def not_in_state(*states)
           states = states.flatten.map(&:to_s)
 
-          if use_most_recent_column?
-            not_in_state_with_most_recent(states)
-          else
-            not_in_state_without_most_recent(states)
-          end
-        end
-
-        private
-
-        def in_state_with_most_recent(states)
-          joins(most_recent_transition_join).
-            where(states_where(most_recent_transition_alias, states), states)
-        end
-
-        def not_in_state_with_most_recent(states)
           joins(most_recent_transition_join).
             where("NOT (#{states_where(most_recent_transition_alias, states)})",
                   states)
         end
 
-        def in_state_without_most_recent(states)
-          joins(transition1_join).
-            joins(transition2_join).
-            where(states_where(most_recent_transition_alias, states), states).
-            where("#{other_transition_alias}.id" => nil)
-        end
-
-        def not_in_state_without_most_recent(states)
-          joins(transition1_join).
-            joins(transition2_join).
-            where("NOT (#{states_where(most_recent_transition_alias, states)})",
-                  states).
-            where("#{other_transition_alias}.id" => nil)
-        end
+        private
 
         def transition_class
           raise NotImplementedError, "A transition_class method should be " \
@@ -80,20 +49,6 @@ module Statesman
           transition_reflection.table_name
         end
 
-        def transition1_join
-          "LEFT OUTER JOIN #{model_table} #{most_recent_transition_alias}
-             ON #{most_recent_transition_alias}.#{model_foreign_key} =
-                  #{table_name}.id"
-        end
-
-        def transition2_join
-          "LEFT OUTER JOIN #{model_table} #{other_transition_alias}
-             ON #{other_transition_alias}.#{model_foreign_key} =
-                  #{table_name}.id
-             AND #{other_transition_alias}.sort_key >
-                   #{most_recent_transition_alias}.sort_key"
-        end
-
         def most_recent_transition_join
           "LEFT OUTER JOIN #{model_table} AS #{most_recent_transition_alias}
              ON #{table_name}.id =
@@ -115,23 +70,8 @@ module Statesman
           "most_recent_#{transition_name.to_s.singularize}"
         end
 
-        def other_transition_alias
-          "other_#{transition_name.to_s.singularize}"
-        end
-
         def db_true
           ::ActiveRecord::Base.connection.quote(true)
-        end
-
-        # Only use the most_recent column if it has a unique index guaranteeing
-        # it has good data
-        def use_most_recent_column?
-          ::ActiveRecord::Base.connection.index_exists?(
-            transition_class.table_name,
-            [model_foreign_key, :most_recent],
-            unique: true,
-            name: "index_#{transition_class.table_name}_parent_most_recent"
-          )
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,13 +71,6 @@ RSpec.configure do |config|
       end
     end
 
-    def drop_most_recent_column
-      silence_stream(STDOUT) do
-        DropMostRecentColumn.migrate(:up)
-        MyActiveRecordModelTransition.reset_column_information
-      end
-    end
-
     def prepare_other_model_table
       silence_stream(STDOUT) do
         CreateOtherActiveRecordModelMigration.migrate(:up)

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -61,129 +61,66 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
     model
   end
 
-  context "with a most_recent column" do
-    describe ".in_state" do
-      context "given a single state" do
-        subject { MyActiveRecordModel.in_state(:succeeded) }
+  describe ".in_state" do
+    context "given a single state" do
+      subject { MyActiveRecordModel.in_state(:succeeded) }
 
-        it { is_expected.to include model }
-        it { is_expected.not_to include other_model }
-        its(:to_sql) { is_expected.to include('.most_recent ') }
-      end
-
-      context "given multiple states" do
-        subject { MyActiveRecordModel.in_state(:succeeded, :failed) }
-
-        it { is_expected.to include model }
-        it { is_expected.to include other_model }
-      end
-
-      context "given the initial state" do
-        subject { MyActiveRecordModel.in_state(:initial) }
-
-        it { is_expected.to include initial_state_model }
-        it { is_expected.to include returned_to_initial_model }
-      end
-
-      context "given an array of states" do
-        subject { MyActiveRecordModel.in_state([:succeeded, :failed]) }
-
-        it { is_expected.to include model }
-        it { is_expected.to include other_model }
-      end
-
-      context "merging two queries" do
-        subject do
-          MyActiveRecordModel.in_state(:succeeded).
-            joins(:other_active_record_model).
-            merge(OtherActiveRecordModel.in_state(:initial))
-        end
-
-        it { is_expected.to be_empty }
-      end
+      it { is_expected.to include model }
+      it { is_expected.not_to include other_model }
     end
 
-    describe ".not_in_state" do
-      context "given a single state" do
-        subject { MyActiveRecordModel.not_in_state(:failed) }
-        it { is_expected.to include model }
-        it { is_expected.not_to include other_model }
-        its(:to_sql) { is_expected.to include('.most_recent ') }
+    context "given multiple states" do
+      subject { MyActiveRecordModel.in_state(:succeeded, :failed) }
+
+      it { is_expected.to include model }
+      it { is_expected.to include other_model }
+    end
+
+    context "given the initial state" do
+      subject { MyActiveRecordModel.in_state(:initial) }
+
+      it { is_expected.to include initial_state_model }
+      it { is_expected.to include returned_to_initial_model }
+    end
+
+    context "given an array of states" do
+      subject { MyActiveRecordModel.in_state([:succeeded, :failed]) }
+
+      it { is_expected.to include model }
+      it { is_expected.to include other_model }
+    end
+
+    context "merging two queries" do
+      subject do
+        MyActiveRecordModel.in_state(:succeeded).
+          joins(:other_active_record_model).
+          merge(OtherActiveRecordModel.in_state(:initial))
       end
 
-      context "given multiple states" do
-        subject { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
-        it do
-          is_expected.to match_array([initial_state_model,
-                                      returned_to_initial_model])
-        end
-      end
-
-      context "given an array of states" do
-        subject { MyActiveRecordModel.not_in_state([:succeeded, :failed]) }
-        it do
-          is_expected.to match_array([initial_state_model,
-                                      returned_to_initial_model])
-        end
-      end
+      it { is_expected.to be_empty }
     end
   end
 
-  context "without a most_recent column" do
-    before { drop_most_recent_column }
+  describe ".not_in_state" do
+    context "given a single state" do
+      subject { MyActiveRecordModel.not_in_state(:failed) }
+      it { is_expected.to include model }
+      it { is_expected.not_to include other_model }
+    end
 
-    describe ".in_state" do
-      context "given a single state" do
-        subject { MyActiveRecordModel.in_state(:succeeded) }
-
-        it { is_expected.to include model }
-        its(:to_sql) { is_expected.not_to include('.most_recent ') }
-      end
-
-      context "given multiple states" do
-        subject { MyActiveRecordModel.in_state(:succeeded, :failed) }
-
-        it { is_expected.to include model }
-        it { is_expected.to include other_model }
-      end
-
-      context "given the initial state" do
-        subject { MyActiveRecordModel.in_state(:initial) }
-
-        it { is_expected.to include initial_state_model }
-        it { is_expected.to include returned_to_initial_model }
-      end
-
-      context "given an array of states" do
-        subject { MyActiveRecordModel.in_state([:succeeded, :failed]) }
-
-        it { is_expected.to include model }
-        it { is_expected.to include other_model }
+    context "given multiple states" do
+      subject { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
+      it do
+        is_expected.to match_array([initial_state_model,
+                                    returned_to_initial_model])
       end
     end
 
-    describe ".not_in_state" do
-      context "given a single state" do
-        subject { MyActiveRecordModel.not_in_state(:failed) }
-        it { is_expected.to include model }
-        it { is_expected.not_to include other_model }
-        its(:to_sql) { is_expected.not_to include('.most_recent ') }
-      end
-
-      context "given multiple states" do
-        subject { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
-        it do
-          is_expected.to match_array([initial_state_model,
-                                      returned_to_initial_model])
-        end
-      end
-
-      context "given an array of states" do
-        subject { MyActiveRecordModel.not_in_state([:succeeded, :failed]) }
-        it do
-          is_expected.to match_array([initial_state_model,
-                                      returned_to_initial_model])
-        end
+    context "given an array of states" do
+      subject { MyActiveRecordModel.not_in_state([:succeeded, :failed]) }
+      it do
+        is_expected.to match_array([initial_state_model,
+                                    returned_to_initial_model])
       end
     end
   end
@@ -200,20 +137,9 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
       end
     end
 
-    context "with a most_recent column" do
-      describe ".in_state" do
-        subject(:query) { MyActiveRecordModel.in_state(:succeeded) }
-        specify { expect { query }.to_not raise_error }
-      end
-    end
-
-    context "without a most_recent column" do
-      before { drop_most_recent_column }
-
-      describe ".in_state" do
-        subject(:query) { MyActiveRecordModel.in_state(:succeeded) }
-        specify { expect { query }.to_not raise_error }
-      end
+    describe ".in_state" do
+      subject(:query) { MyActiveRecordModel.in_state(:succeeded) }
+      specify { expect { query }.to_not raise_error }
     end
   end
 end

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -131,7 +131,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
       end
     end
 
-    context "when the transition_class has a most_recent column" do
+    describe "updating the most_recent column" do
       subject { create }
 
       context "with no previous transition" do
@@ -188,11 +188,6 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
             from(true).to be_falsey
         end
       end
-    end
-
-    context "when the transition_class doesn't have a most_recent column" do
-      before { drop_most_recent_column }
-      it { is_expected.to_not raise_exception }
     end
   end
 

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -164,8 +164,8 @@ class CreateOtherActiveRecordModelTransitionMigration < ActiveRecord::Migration
     end
   end
 end
-
 # rubocop:enable MethodLength
+
 class DropMostRecentColumn < ActiveRecord::Migration
   def change
     remove_index :my_active_record_model_transitions,
@@ -216,6 +216,7 @@ class CreateNamespacedARModelMigration < ActiveRecord::Migration
   end
 end
 
+# rubocop:disable MethodLength
 class CreateNamespacedARModelTransitionMigration < ActiveRecord::Migration
   def change
     create_table :my_namespace_my_active_record_model_transitions do |t|
@@ -230,10 +231,32 @@ class CreateNamespacedARModelTransitionMigration < ActiveRecord::Migration
         t.text :metadata, default: '{}'
       end
 
+      if Statesman::Adapters::ActiveRecord.database_supports_partial_indexes?
+        t.boolean :most_recent, default: true, null: false
+      else
+        t.boolean :most_recent, default: true
+      end
+
       t.timestamps null: false
     end
 
     add_index :my_namespace_my_active_record_model_transitions, :sort_key,
               unique: true, name: 'my_namespaced_key'
+
+    if Statesman::Adapters::ActiveRecord.database_supports_partial_indexes?
+      add_index :my_namespace_my_active_record_model_transitions,
+                [:my_active_record_model_id, :most_recent],
+                unique: true,
+                where: "most_recent",
+                name: "index_namespace_model_transitions_"\
+                      "parent_most_recent"
+    else
+      add_index :my_namespace_my_active_record_model_transitions,
+                [:my_active_record_model_id, :most_recent],
+                unique: true,
+                name: "index_namespace_model_transitions_"\
+                      "parent_most_recent"
+    end
   end
+  # rubocop:enable MethodLength
 end


### PR DESCRIPTION
Previously we were accommodating for not having a `most_recent` column. In 2.0 we should require that column.