### PR TITLE
Increase the default initial sort key to 10

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -98,7 +98,7 @@ module Statesman
       end
 
       def next_sort_key
-        (last && last.sort_key + 10) || 0
+        (last && last.sort_key + 10) || 10
       end
 
       def serialized?(transition_class)

--- a/lib/statesman/adapters/memory.rb
+++ b/lib/statesman/adapters/memory.rb
@@ -35,7 +35,7 @@ module Statesman
       private
 
       def next_sort_key
-        (last && last.sort_key + 10) || 0
+        (last && last.sort_key + 10) || 10
       end
     end
   end

--- a/lib/statesman/adapters/mongoid.rb
+++ b/lib/statesman/adapters/mongoid.rb
@@ -55,7 +55,7 @@ module Statesman
       end
 
       def next_sort_key
-        (last && last.sort_key + 10) || 0
+        (last && last.sort_key + 10) || 10
       end
     end
   end

--- a/spec/statesman/adapters/shared_examples.rb
+++ b/spec/statesman/adapters/shared_examples.rb
@@ -47,12 +47,12 @@ shared_examples_for "an adapter" do |adapter_class, transition_class, options = 
       end
 
       context "with no previous transition" do
-        its(:sort_key) { is_expected.to be(0) }
+        its(:sort_key) { is_expected.to be(10) }
       end
 
       context "with a previous transition" do
         before { adapter.create(from, to) }
-        its(:sort_key) { is_expected.to be(10) }
+        its(:sort_key) { is_expected.to be(20) }
       end
     end
 


### PR DESCRIPTION
We use intervals of 10 between sort_keys so that we can inject
intermediate states easily later on, whilst maintaining a correct
chronological ordering.

The current sort_key default for the initial state is 0, which means
that you can't really inject a new initial state easily (without going
negative).

@hmarr can you review?