### PR TITLE
Add in_state? instance method

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,9 @@ number of retry attempts (defaults to 1).
 #### `Machine#current_state`
 Returns the current state based on existing transition objects.
 
+### `Machine#in_state?(:state_1, :state_2, ...)`
+Returns true if the machine is in any of the given states.
+
 #### `Machine#history`
 Returns a sorted array of all transition objects.
 

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -177,9 +177,9 @@ module Statesman
     end
 
     def initialize(object,
-                      options = {
-                        transition_class: Statesman::Adapters::MemoryTransition
-                      })
+                   options = {
+                     transition_class: Statesman::Adapters::MemoryTransition
+                   })
       @object = object
       @transition_class = options[:transition_class]
       @storage_adapter = adapter_class(@transition_class).new(
@@ -190,6 +190,10 @@ module Statesman
     def current_state
       last_action = last_transition
       last_action ? last_action.to_state : self.class.initial_state
+    end
+
+    def in_state?(*states)
+      states.flatten.any? { |state| current_state == state.to_s }
     end
 
     def allowed_transitions

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -374,6 +374,61 @@ describe Statesman::Machine do
     end
   end
 
+  describe "#in_state?" do
+    before do
+      machine.class_eval do
+        state :x, initial: true
+        state :y
+        transition from: :x, to: :y
+      end
+    end
+
+    let(:instance) { machine.new(my_model) }
+    subject { instance.in_state?(state) }
+    before { instance.transition_to!(:y) }
+
+    context "when machine is in given state" do
+      let(:state) { "y" }
+      it { is_expected.to eq(true) }
+    end
+
+    context "when machine is not in given state" do
+      let(:state) { "x" }
+      it { is_expected.to eq(false) }
+    end
+
+    context "when given a symbol" do
+      let(:state) { :y }
+      it { is_expected.to eq(true) }
+    end
+
+    context "when given multiple states" do
+      context "when given multiple arguments" do
+        context "when one of the states is the current state" do
+          subject { instance.in_state?(:x, :y) }
+          it { is_expected.to eq(true) }
+        end
+
+        context "when none of the states are the current state" do
+          subject { instance.in_state?(:x, :z) }
+          it { is_expected.to eq(false) }
+        end
+      end
+
+      context "when given an array" do
+        context "when one of the states is the current state" do
+          subject { instance.in_state?([:x, :y]) }
+          it { is_expected.to eq(true) }
+        end
+
+        context "when none of the states are the current state" do
+          subject { instance.in_state?([:x, :z]) }
+          it { is_expected.to eq(false) }
+        end
+      end
+    end
+  end
+
   describe "#allowed_transitions" do
     before do
       machine.class_eval do


### PR DESCRIPTION
Example usage:

```ruby
machine.in_state?(:pending)
# => true

machine.in_state?("pending")
# => true

machine.in_state?(:cancelled)
# => false

machine.in_state?(:pending, :cancelled)
# => true

machine.in_state?("some nonsense state")
# => false
```

@greysteil thoughts?