### PR TITLE
Make using cache for last_transition optional

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -51,8 +51,12 @@ module Statesman
         end
       end
 
-      def last
-        @last_transition ||= history.last
+      def last(force_reload: false)
+        if force_reload
+          @last_transition = history.last
+        else
+          @last_transition ||= history.last
+        end
       end
 
       private

--- a/lib/statesman/adapters/memory.rb
+++ b/lib/statesman/adapters/memory.rb
@@ -28,7 +28,7 @@ module Statesman
         transition
       end
 
-      def last
+      def last(*)
         @history.sort_by(&:sort_key).last
       end
 

--- a/lib/statesman/adapters/mongoid.rb
+++ b/lib/statesman/adapters/mongoid.rb
@@ -36,8 +36,12 @@ module Statesman
         transitions_for_parent.asc(:sort_key)
       end
 
-      def last
-        @last_transition ||= history.last
+      def last(force_reload: false)
+        if force_reload
+          @last_transition = history.last
+        else
+          @last_transition ||= history.last
+        end
       end
 
       private

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -187,8 +187,8 @@ module Statesman
       send(:after_initialize) if respond_to? :after_initialize
     end
 
-    def current_state
-      last_action = last_transition
+    def current_state(force_reload: false)
+      last_action = last_transition(force_reload: force_reload)
       last_action ? last_action.to_state : self.class.initial_state
     end
 
@@ -202,8 +202,8 @@ module Statesman
       end
     end
 
-    def last_transition
-      @storage_adapter.last
+    def last_transition(force_reload: false)
+      @storage_adapter.last(force_reload: force_reload)
     end
 
     def can_transition_to?(new_state, metadata = {})

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -207,10 +207,30 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
         adapter.last
       end
 
-      context "and a new transition" do
+      context "after then creating a new transition" do
         before { adapter.create(:y, :z, []) }
         it "retrieves the new transition from the database" do
           expect(adapter.last.to_state).to eq("z")
+        end
+      end
+
+      context "when a new transition has been created elsewhere" do
+        let(:alternate_adapter) do
+          described_class.new(MyActiveRecordModelTransition, model, observer)
+        end
+
+        before { alternate_adapter.create(:y, :z, []) }
+
+        it "still returns the cached value" do
+          expect_any_instance_of(MyActiveRecordModel).
+            to receive(:my_active_record_model_transitions).never
+          expect(adapter.last.to_state).to eq("y")
+        end
+
+        context "when explitly not using the cache" do
+          it "still returns the cached value" do
+            expect(adapter.last(force_reload: true).to_state).to eq("z")
+          end
         end
       end
     end

--- a/spec/statesman/adapters/shared_examples.rb
+++ b/spec/statesman/adapters/shared_examples.rb
@@ -118,5 +118,8 @@ shared_examples_for "an adapter" do |adapter_class, transition_class, options = 
 
     it { is_expected.to be_a(transition_class) }
     specify { expect(adapter.last.to_state.to_sym).to eq(:z) }
+    specify do
+      expect(adapter.last(force_reload: true).to_state.to_sym).to eq(:z)
+    end
   end
 end


### PR DESCRIPTION
@greysteil What do you think? Need to add specs for other adapters but it's a first cut.