### PR TITLE
ActiveRecord::ConnectionAdapters::PostgreSQLColumn no longer responds to #cast_type

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -108,6 +108,7 @@ module Statesman
       def serialized?(transition_class)
         if ::ActiveRecord.respond_to?(:gem_version) &&
            ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0.a')
+          transition_class.columns_hash["metadata"].try(:cast_type) &&
           transition_class.columns_hash["metadata"].
             cast_type.is_a?(::ActiveRecord::Type::Serialized)
         else


### PR DESCRIPTION
Hi guys - 

We're using Rails 5 and trying to setup the `statesman` gem as our state machine.

Prior to working off of this branch (in which I implemented a crude fix), any effort to query our model's associated state machine resulted in an error like this:

```
NoMethodError: undefined method `cast_type' for #<ActiveRecord::ConnectionAdapters::PostgreSQLColumn:0x007fc9a2c67e10>
from /Users/mec/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/statesman-1.3.1/lib/statesman/adapters/active_record.rb:114:in `serialized?'
```

I believe the cause of this may be that [the Rails attributes API has changed in Rails 5](http://edgeapi.rubyonrails.org/classes/ActiveRecord/Attributes/ClassMethods.html), but I'm not 100%. We'll keep maintaining this fork on our end and address Rails 5 compatibility issues as we go. Thanks.

### Usage with this branch's fix

```
[4] pry(main)> ach_file.current_state
  AchFileTransition Load (0.6ms)  SELECT  "ach_file_transitions".* FROM "ach_file_transitions" WHERE "ach_file_transitions"."ach_file_id" = $1 ORDER BY "ach_file_transitions"."sort_key" DESC LIMIT $2  [["ach_file_id", 1], ["LIMIT", 1]]
"pending"
```

cc @jakehow @tylermachen