### PR TITLE
Ensure consistency in the migration template

### DIFF
--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -15,7 +15,6 @@ class Create<%= migration_class_name %> < ActiveRecord::Migration
               name: "<%= index_name :parent_sort %>")
     add_index(:<%= table_name %>,
               [:<%= parent_id %>, :most_recent],
-              unique: true,
               <%= "where: 'most_recent'," if database_supports_partial_indexes? %>
               name: "<%= index_name :parent_most_recent %>")
   end


### PR DESCRIPTION
Hi,

There seems to be an inconsistency in the migration template.
Parent id and the `most_recent`columns should not be unique.

I would appreciate if you check this.
Thank you.