### PR TITLE
Remove use of cast_type

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -108,8 +108,8 @@ module Statesman
       def serialized?(transition_class)
         if ::ActiveRecord.respond_to?(:gem_version) &&
            ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0.a')
-          transition_class.columns_hash["metadata"].
-            cast_type.is_a?(::ActiveRecord::Type::Serialized)
+          transition_class.type_for_attribute("metadata").
+            is_a?(::ActiveRecord::Type::Serialized)
         else
           transition_class.serialized_attributes.include?("metadata")
         end

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -22,9 +22,11 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
                                            { 'metadata' => metadata_column })
         if ::ActiveRecord.respond_to?(:gem_version) &&
            ::ActiveRecord.gem_version >= Gem::Version.new('4.2.0.a')
-          allow(metadata_column).to receive_messages(cast_type: '')
+          expect(MyActiveRecordModelTransition).
+            to receive(:type_for_attribute).with("metadata").
+            and_return(ActiveRecord::Type::Value.new)
         else
-          allow(MyActiveRecordModelTransition).
+          expect(MyActiveRecordModelTransition).
             to receive_messages(serialized_attributes: {})
         end
       end
@@ -48,8 +50,8 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
           serialized_type = ::ActiveRecord::Type::Serialized.new(
             '', ::ActiveRecord::Coders::JSON
           )
-          expect(metadata_column).
-            to receive(:cast_type).
+          expect(MyActiveRecordModelTransition).
+            to receive(:type_for_attribute).with("metadata").
             and_return(serialized_type)
         else
           expect(MyActiveRecordModelTransition).
@@ -76,8 +78,8 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
           serialized_type = ::ActiveRecord::Type::Serialized.new(
             '', ::ActiveRecord::Coders::JSON
           )
-          expect(metadata_column).
-            to receive(:cast_type).
+          expect(MyActiveRecordModelTransition).
+            to receive(:type_for_attribute).with("metadata").
             and_return(serialized_type)
         else
           expect(MyActiveRecordModelTransition).


### PR DESCRIPTION
`Column#cast_type` is deprecated in Rails 5, and with hindsight I'm not sure why we were ever using it...

Kudos to @brunoalano and @kenchan0130 for raising and discussing in https://github.com/gocardless/statesman/issues/202.