### PR TITLE
Handle custom transition association names gracefully

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -38,7 +38,13 @@ module Statesman
         end
 
         def transition_reflection
-          reflect_on_association(transition_name)
+          reflect_on_all_associations(:has_many).each do |value|
+            return value if value.klass == transition_class
+          end
+
+          raise MissingTransitionAssociation,
+                "Could not find has_many association between #{self.class} " \
+                "and #{transition_class}."
         end
 
         def model_foreign_key

--- a/lib/statesman/exceptions.rb
+++ b/lib/statesman/exceptions.rb
@@ -5,6 +5,7 @@ module Statesman
   class GuardFailedError < StandardError; end
   class TransitionFailedError < StandardError; end
   class TransitionConflictError < StandardError; end
+  class MissingTransitionAssociation < StandardError; end
 
   class UnserializedMetadataError < StandardError
     def initialize(transition_class_name)


### PR DESCRIPTION
Previously, statesman required the association with the transition class to use
the exact name of the transition class, unless a `transition_name` was specified
along with the `transition_class`.

This PR updates the way we look for the association with the transition class so
as `transition_name` no longer needs to be overridden to work with custom named
associations.

Fixes https://github.com/gocardless/statesman/issues/220.
