### PR TITLE
Lock the parent object to prevent deadlocks updating most_recent

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -70,7 +70,7 @@ module Statesman
 
         transition = transitions_for_parent.build(transition_attributes)
 
-        ::ActiveRecord::Base.transaction do
+        @parent_model.with_lock do
           @observer.execute(:before, from, to, transition)
           unset_old_most_recent
           transition.save!


### PR DESCRIPTION
In [`unset_old_most_recent`](https://github.com/gocardless/statesman/blob/master/lib/statesman/adapters/active_record.rb#L89-L102) it is easy to get deadlocks from this code:

```
transitions_for_parent.update_all(most_recent: false)
```

The problem is that it updates several rows, and concurrent updates may not update the rows in the same order. This causes [deadlocks](http://stackoverflow.com/questions/16735950/update-with-order-by) in [Postgres](http://dba.stackexchange.com/questions/68388/optimizing-concurrent-updates-in-postgres).

This commit fixes the problem by locking the parent object before altering its status transitions.

I wasn't really sure how to write a test for this, although in my own project I could reproduce the problem right away by running this in two shells at once:

```
# script/c.rb
# run with `rails runner script/c.rb`
c = Contact.find 20159
while true do
  10.times do
    c.state_machine.trigger(:archive)
    c.state_machine.trigger(:activate)
  end
  print "."
  STDOUT.flush
end
```
