### PR TITLE
Fix typo in spec/support/active_record.rb

### DIFF
--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -187,7 +187,7 @@ module MyNamespace
 
     def state_machine
       @state_machine ||= MyStateMachine.new(
-        self, transition_class: MyNameSpace::MyActiveRecordModelTransition,
+        self, transition_class: MyNamespace::MyActiveRecordModelTransition,
               association_name: :my_active_record_model_transitions)
     end
 


### PR DESCRIPTION
Fixed wrong module name. 😸 