### PR TITLE
Lock nokogiri dependency on Ruby 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ env:
   - "RAILS_VERSION=3.2.21"
   - "RAILS_VERSION=4.0.13"
   - "RAILS_VERSION=4.1.14"
-  - "RAILS_VERSION=4.2.5"
-  - "RAILS_VERSION=4.2.5 DATABASE_URL=mysql2://root@localhost/statesman_test"
-  - "RAILS_VERSION=4.2.5 DATABASE_URL=postgres://postgres@localhost/statesman_test"
+  - "RAILS_VERSION=4.2.5 NOKOGIRI_VERSION=1.6.8"
+  - "RAILS_VERSION=4.2.5 NOKOGIRI_VERSION=1.6.8 DATABASE_URL=mysql2://root@localhost/statesman_test"
+  - "RAILS_VERSION=4.2.5 NOKOGIRI_VERSION=1.6.8 DATABASE_URL=postgres://postgres@localhost/statesman_test"
   - "RAILS_VERSION=5.0.0 EXCLUDE_MONGOID=true"
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ sudo: false
 
 services: mongodb
 
+branches:
+  only:
+    - "master"
+
 before_script:
   - mysql -e 'CREATE DATABASE statesman_test;'
   - psql -c 'CREATE DATABASE statesman_test;' -U postgres

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,10 @@ gemspec
 
 gem "rails", "~> #{ENV["RAILS_VERSION"]}" if ENV["RAILS_VERSION"]
 
+if ENV["NOKOGIRI_VERSION"]
+  gem "nokogiri", "~> #{ENV["NOKOGIRI_VERSION"]}"
+end
+
 group :development do
   gem "mongoid", ">= 3.1" unless ENV["EXCLUDE_MONGOID"]
 


### PR DESCRIPTION
Nokogiri 1.7 removes support for Ruby 2.0, even though Rails 4.2 will run on this version of Ruby. This downgrades the dependency to the last 2.0-supporting version of Nokogiri.