### PR TITLE
Remove Ruby 2.0 support from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: ruby
 
 rvm:
-  - 2.3.0
-  - 2.2.4
-  - 2.1
-  - 2.0.0
+  - 2.3.3
+  - 2.2.6
+  - 2.1.9
 
 sudo: false
 
 services: mongodb
+
+before_install:
+ - gem update --system
+ - gem install bundler
 
 before_script:
   - mysql -e 'CREATE DATABASE statesman_test;'
@@ -29,7 +32,5 @@ env:
 
 matrix:
   exclude:
-    - rvm: 2.1
-      env: "RAILS_VERSION=5.0.0 EXCLUDE_MONGOID=true"
-    - rvm: 2.0.0
+    - rvm: 2.1.9
       env: "RAILS_VERSION=5.0.0 EXCLUDE_MONGOID=true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ before_install:
  - gem update --system
  - gem install bundler
 
+branches:
+  only:
+    - "master"
+
 before_script:
   - mysql -e 'CREATE DATABASE statesman_test;'
   - psql -c 'CREATE DATABASE statesman_test;' -U postgres


### PR DESCRIPTION
Ruby 2.0 is [no longer officially supported as of 24/Feb/2016](https://www.ruby-lang.org/en/news/2016/02/24/support-plan-of-ruby-2-0-0-and-2-1/). This also forces Travis to use the latest patch versions for the other rubies (by default, it will install patch version `0`).

Users should upgrade to at least Ruby 2.1 as soon as possible.