### PR TITLE
Remove double-space from generated transition models

### DIFF
--- a/lib/generators/statesman/active_record_transition_generator.rb
+++ b/lib/generators/statesman/active_record_transition_generator.rb
@@ -24,7 +24,7 @@ module Statesman
       "db/migrate/#{next_migration_number}_create_#{table_name}.rb"
     end
 
-    def rails_4?
+    def rails_4_or_higher?
       Rails.version.split(".").map(&:to_i).first >= 4
     end
   end

--- a/lib/generators/statesman/templates/active_record_transition_model.rb.erb
+++ b/lib/generators/statesman/templates/active_record_transition_model.rb.erb
@@ -1,9 +1,10 @@
 class <%= klass %> < ActiveRecord::Base
   include Statesman::Adapters::ActiveRecordTransition
 
-<% unless rails_4? %>
+<%- unless rails_4_or_higher? -%>
   attr_accessible :to_state, :metadata, :sort_key
-<% end %>
+
+<%- end -%>
   belongs_to :<%= parent_name %><%= class_name_option %>, inverse_of: :<%= table_name %>
 
   after_destroy :update_most_recent, if: :most_recent?

--- a/spec/generators/statesman/active_record_transition_generator_spec.rb
+++ b/spec/generators/statesman/active_record_transition_generator_spec.rb
@@ -23,4 +23,11 @@ describe Statesman::ActiveRecordTransitionGenerator, type: :generator do
     it { is_expected.not_to contain(/class_name:/) }
     it { is_expected.to contain(/class BaconTransition/) }
   end
+
+  describe "it doesn't create any double-spacing" do
+    before { run_generator %w(Yummy::Bacon Yummy::BaconTransition) }
+    subject { file('app/models/yummy/bacon_transition.rb') }
+
+    it { is_expected.to_not contain(/\n\n\n/) }
+  end
 end


### PR DESCRIPTION
Also renames a confusing helper method.