### PR TITLE
Support ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 
 rvm:
+  - 2.4.1
   - 2.3.3
   - 2.2.6
   - 2.1.9
@@ -29,12 +30,18 @@ env:
   - "RAILS_VERSION=3.2.21"
   - "RAILS_VERSION=4.0.13"
   - "RAILS_VERSION=4.1.14"
-  - "RAILS_VERSION=4.2.5"
-  - "RAILS_VERSION=4.2.5 DATABASE_URL=mysql2://root@localhost/statesman_test"
-  - "RAILS_VERSION=4.2.5 DATABASE_URL=postgres://postgres@localhost/statesman_test"
+  - "RAILS_VERSION=4.2.8"
+  - "RAILS_VERSION=4.2.8 DATABASE_URL=mysql2://root@localhost/statesman_test"
+  - "RAILS_VERSION=4.2.8 DATABASE_URL=postgres://postgres@localhost/statesman_test"
   - "RAILS_VERSION=5.0.0 EXCLUDE_MONGOID=true"
 
 matrix:
   exclude:
     - rvm: 2.1.9
       env: "RAILS_VERSION=5.0.0 EXCLUDE_MONGOID=true"
+    - rvm: 2.4.1
+      env: "RAILS_VERSION=3.2.21"
+    - rvm: 2.4.1
+      env: "RAILS_VERSION=4.0.13"
+    - rvm: 2.4.1
+      env: "RAILS_VERSION=4.1.14"


### PR DESCRIPTION
Add test case for ruby 2.4 in CI.

And upgrade rails version from 4.2.5 to 4.2.8 because [the rails team has announced](http://weblog.rubyonrails.org/2017/2/21/Rails-4-2-8-has-been-released/) that it supported ruby 2.4 with rails 4.2.8.