### PR TITLE
Support rails 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,14 @@ env:
   - "RAILS_VERSION=4.2.8 DATABASE_URL=mysql2://root@localhost/statesman_test"
   - "RAILS_VERSION=4.2.8 DATABASE_URL=postgres://postgres@localhost/statesman_test"
   - "RAILS_VERSION=5.0.3 EXCLUDE_MONGOID=true"
+  - "RAILS_VERSION=5.1.1 EXCLUDE_MONGOID=true"
 
 matrix:
   exclude:
     - rvm: 2.1.9
       env: "RAILS_VERSION=5.0.3 EXCLUDE_MONGOID=true"
+    - rvm: 2.1.9
+      env: "RAILS_VERSION=5.1.1 EXCLUDE_MONGOID=true"
     - rvm: 2.4.1
       env: "RAILS_VERSION=3.2.21"
     - rvm: 2.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,12 +33,12 @@ env:
   - "RAILS_VERSION=4.2.8"
   - "RAILS_VERSION=4.2.8 DATABASE_URL=mysql2://root@localhost/statesman_test"
   - "RAILS_VERSION=4.2.8 DATABASE_URL=postgres://postgres@localhost/statesman_test"
-  - "RAILS_VERSION=5.0.0 EXCLUDE_MONGOID=true"
+  - "RAILS_VERSION=5.0.3 EXCLUDE_MONGOID=true"
 
 matrix:
   exclude:
     - rvm: 2.1.9
-      env: "RAILS_VERSION=5.0.0 EXCLUDE_MONGOID=true"
+      env: "RAILS_VERSION=5.0.3 EXCLUDE_MONGOID=true"
     - rvm: 2.4.1
       env: "RAILS_VERSION=3.2.21"
     - rvm: 2.4.1

--- a/lib/generators/statesman/active_record_transition_generator.rb
+++ b/lib/generators/statesman/active_record_transition_generator.rb
@@ -27,5 +27,9 @@ module Statesman
     def rails_4_or_higher?
       Rails.version.split(".").map(&:to_i).first >= 4
     end
+
+    def rails_5_or_higher?
+      Rails.version.split(".").map(&:to_i).first >= 5
+    end
   end
 end

--- a/lib/generators/statesman/generator_helpers.rb
+++ b/lib/generators/statesman/generator_helpers.rb
@@ -40,5 +40,13 @@ module Statesman
     def database_supports_partial_indexes?
       Statesman::Adapters::ActiveRecord.database_supports_partial_indexes?
     end
+
+    def metadata_default_value
+      rails_5_or_higher? ? "{}" : "{}".inspect
+    end
+
+    def rails_5_or_higher?
+      Rails.version.split(".").map(&:to_i).first >= 5
+    end
   end
 end

--- a/lib/generators/statesman/templates/active_record_transition_model.rb.erb
+++ b/lib/generators/statesman/templates/active_record_transition_model.rb.erb
@@ -1,4 +1,4 @@
-class <%= klass %> < ActiveRecord::Base
+class <%= klass %> < <%= rails_5_or_higher? ? 'ApplicationRecord' : 'ActiveRecord::Base' %>
   include Statesman::Adapters::ActiveRecordTransition
 
 <%- unless rails_4_or_higher? -%>

--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -1,8 +1,8 @@
-class Create<%= migration_class_name %> < ActiveRecord::Migration
+class Create<%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveRecord::Migration.current_version}]" if rails_5_or_higher? %>
   def change
     create_table :<%= table_name %> do |t|
       t.string :to_state, null: false
-      t.text :metadata<%= ", default: \"{}\"" unless mysql? %>
+      t.text :metadata<%= ", default: #{metadata_default_value}" unless mysql? %>
       t.integer :sort_key, null: false
       t.integer :<%= parent_id %>, null: false
       t.boolean :most_recent<%= ", null: false" if database_supports_partial_indexes? %>

--- a/lib/generators/statesman/templates/update_migration.rb.erb
+++ b/lib/generators/statesman/templates/update_migration.rb.erb
@@ -1,7 +1,7 @@
-class AddStatesmanTo<%= migration_class_name %> < ActiveRecord::Migration
+class AddStatesmanTo<%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveRecord::Migration.current_version}]" if rails_5_or_higher? %>
   def change
     add_column :<%= table_name %>, :to_state, :string, null: false
-    add_column :<%= table_name %>, :metadata, :text<%= ", default: \"{}\"" unless mysql? %>
+    add_column :<%= table_name %>, :metadata, :text<%= ", default: #{metadata_default_value}" unless mysql? %>
     add_column :<%= table_name %>, :sort_key, :integer, null: false
     add_column :<%= table_name %>, :<%= parent_id %>, :integer, null: false
     add_column :<%= table_name %>, :most_recent, null: false

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -123,7 +123,14 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
       end
 
       context "ActiveRecord::RecordNotUnique unrelated to this transition" do
-        let(:error) { ActiveRecord::RecordNotUnique.new("unrelated", nil) }
+        let(:error) do
+          if ::ActiveRecord.respond_to?(:gem_version) &&
+             ::ActiveRecord.gem_version >= Gem::Version.new('4.0.0')
+            ActiveRecord::RecordNotUnique.new("unrelated")
+          else
+            ActiveRecord::RecordNotUnique.new("unrelated", nil)
+          end
+        end
         it { is_expected.to raise_exception(ActiveRecord::RecordNotUnique) }
       end
 

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -1,5 +1,11 @@
-require "support/active_record"
 require "json"
+
+MIGRATION_CLASS = if Rails.version.split(".").map(&:to_i).first >= 5
+                    migration_version = ActiveRecord::Migration.current_version
+                    ActiveRecord::Migration[migration_version]
+                  else
+                    ActiveRecord::Migration
+                  end
 
 class MyStateMachine
   include Statesman::Machine
@@ -33,7 +39,7 @@ class MyActiveRecordModelTransition < ActiveRecord::Base
   serialize :metadata, JSON
 end
 
-class CreateMyActiveRecordModelMigration < ActiveRecord::Migration
+class CreateMyActiveRecordModelMigration < MIGRATION_CLASS
   def change
     create_table :my_active_record_models do |t|
       t.string :current_state
@@ -44,7 +50,7 @@ end
 
 # TODO: make this a module we can extend from the app? Or a generator?
 # rubocop:disable MethodLength
-class CreateMyActiveRecordModelTransitionMigration < ActiveRecord::Migration
+class CreateMyActiveRecordModelTransitionMigration < MIGRATION_CLASS
   def change
     create_table :my_active_record_model_transitions do |t|
       t.string  :to_state
@@ -110,7 +116,7 @@ class OtherActiveRecordModelTransition < ActiveRecord::Base
   serialize :metadata, JSON
 end
 
-class CreateOtherActiveRecordModelMigration < ActiveRecord::Migration
+class CreateOtherActiveRecordModelMigration < MIGRATION_CLASS
   def change
     create_table :other_active_record_models do |t|
       t.string :current_state
@@ -121,7 +127,7 @@ class CreateOtherActiveRecordModelMigration < ActiveRecord::Migration
 end
 
 # rubocop:disable MethodLength
-class CreateOtherActiveRecordModelTransitionMigration < ActiveRecord::Migration
+class CreateOtherActiveRecordModelTransitionMigration < MIGRATION_CLASS
   def change
     create_table :other_active_record_model_transitions do |t|
       t.string  :to_state
@@ -166,7 +172,7 @@ class CreateOtherActiveRecordModelTransitionMigration < ActiveRecord::Migration
 end
 # rubocop:enable MethodLength
 
-class DropMostRecentColumn < ActiveRecord::Migration
+class DropMostRecentColumn < MIGRATION_CLASS
   def change
     remove_index :my_active_record_model_transitions,
                  name: "index_my_active_record_model_transitions_"\
@@ -207,7 +213,7 @@ module MyNamespace
   end
 end
 
-class CreateNamespacedARModelMigration < ActiveRecord::Migration
+class CreateNamespacedARModelMigration < MIGRATION_CLASS
   def change
     create_table :my_namespace_my_active_record_models do |t|
       t.string :current_state
@@ -217,7 +223,7 @@ class CreateNamespacedARModelMigration < ActiveRecord::Migration
 end
 
 # rubocop:disable MethodLength
-class CreateNamespacedARModelTransitionMigration < ActiveRecord::Migration
+class CreateNamespacedARModelTransitionMigration < MIGRATION_CLASS
   def change
     create_table :my_namespace_my_active_record_model_transitions do |t|
       t.string  :to_state


### PR DESCRIPTION
This PR depends on https://github.com/gocardless/statesman/pull/243.

---

[Removed deprecated original_exception argument in `ActiveRecord::StatementInvalid#initialize` and `ActiveRecord::StatementInvalid#original_exception`](
https://github.com/rails/rails/commit/bc6c5df4699d3f6b4a61dd12328f9e0f1bd6cf46) in rails 5.1.

So, I remove the second argument which is `nil` because the line of `spec/statesman/adapters/active_record_spec.rb` passed `nil` to `ActiveRecord::StatementInvalid#initialize`

