### PR TITLE
Add foreign keys when creating a new transition table

### DIFF
--- a/lib/generators/statesman/generator_helpers.rb
+++ b/lib/generators/statesman/generator_helpers.rb
@@ -20,6 +20,10 @@ module Statesman
       parent.demodulize.underscore
     end
 
+    def parent_table_name
+      parent.demodulize.underscore.pluralize
+    end
+
     def parent_id
       parent_name + "_id"
     end

--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -9,6 +9,7 @@ class Create<%= migration_class_name %> < ActiveRecord::Migration
       t.timestamps null: false
     end
 
+    # Foreign keys are optional, but highly recommended
     add_foreign_key :<%= table_name %>, :<%= parent_table_name %>
 
     add_index(:<%= table_name %>,

--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -9,6 +9,8 @@ class Create<%= migration_class_name %> < ActiveRecord::Migration
       t.timestamps null: false
     end
 
+    add_foreign_key :<%= table_name %>, :<%= parent_table_name %>
+
     add_index(:<%= table_name %>,
               [:<%= parent_id %>, :sort_key],
               unique: true,

--- a/spec/generators/statesman/active_record_transition_generator_spec.rb
+++ b/spec/generators/statesman/active_record_transition_generator_spec.rb
@@ -7,6 +7,20 @@ describe Statesman::ActiveRecordTransitionGenerator, type: :generator do
     let(:migration_name) { 'db/migrate/create_bacon_transitions.rb' }
   end
 
+  describe 'creates a migration' do
+    subject { file("db/migrate/#{time}_create_bacon_transitions.rb") }
+
+    before { allow(Time).to receive(:now).and_return(mock_time) }
+    before { run_generator %w(Yummy::Bacon Yummy::BaconTransition) }
+
+    let(:mock_time) { double('Time', utc: double('UTCTime', strftime: time)) }
+    let(:time) { '5678309' }
+
+    it "includes a foreign key" do
+      expect(subject).to contain("add_foreign_key :bacon_transitions, :bacons")
+    end
+  end
+
   describe 'properly adds class names' do
     before { run_generator %w(Yummy::Bacon Yummy::BaconTransition) }
     subject { file('app/models/yummy/bacon_transition.rb') }


### PR DESCRIPTION
Because `Statesman is ... designed to provide ... data integrity.`. :octocat: 