### PR TITLE
Enforce real nested transactions

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -72,7 +72,7 @@ module Statesman
 
         transition = transitions_for_parent.build(transition_attributes)
 
-        ::ActiveRecord::Base.transaction do
+        ::ActiveRecord::Base.transaction(requires_new: true) do
           @observer.execute(:before, from, to, transition)
           unset_old_most_recent
           transition.save!

--- a/lib/tasks/statesman.rake
+++ b/lib/tasks/statesman.rake
@@ -19,7 +19,7 @@ namespace :statesman do
     batch_size = 500
 
     parent_class.find_in_batches(batch_size: batch_size) do |models|
-      ActiveRecord::Base.transaction do
+      ActiveRecord::Base.transaction(requires_new: true) do
         if Statesman::Adapters::ActiveRecord.database_supports_partial_indexes?
           # Set all transitions' most_recent to FALSE
           transition_class.where(parent_fk => models.map(&:id)).

--- a/statesman.gemspec
+++ b/statesman.gemspec
@@ -31,6 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-its", "~> 1.1"
   spec.add_development_dependency "rspec-rails", "~> 3.1"
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4.0"
-  spec.add_development_dependency "sqlite3", "~> 1.3"
+  spec.add_development_dependency "sqlite3", "~> 1.3.6"
   spec.add_development_dependency "timecop", "~> 0.9.1"
 end


### PR DESCRIPTION
`requires_new: true` forces Rails to create real nested transactions in
databases that support it. This keeps proper transaction semantics when
transitioning a state machine inside a larger transaction.