### PR TITLE
Don't make transition_class a private method in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ class Order < ActiveRecord::Base
   def self.transition_class
     OrderTransition
   end
-  private_class_method :transition_class
 
   def self.initial_state
     :pending
@@ -319,7 +318,6 @@ class Order < ActiveRecord::Base
   def self.transition_class
     OrderTransition
   end
-  private_class_method :transition_class
 
   def self.initial_state
     OrderStateMachine.initial_state


### PR DESCRIPTION
This will result in the `backfill_most_recent` task failing because it
attempts to call this method from outside the class.

Fixes #232