### PR TITLE
Enable determining which guard failed causing a GuardFailedError

### DIFF
--- a/lib/statesman/exceptions.rb
+++ b/lib/statesman/exceptions.rb
@@ -2,10 +2,18 @@ module Statesman
   class InvalidStateError < StandardError; end
   class InvalidTransitionError < StandardError; end
   class InvalidCallbackError < StandardError; end
-  class GuardFailedError < StandardError; end
   class TransitionFailedError < StandardError; end
   class TransitionConflictError < StandardError; end
   class MissingTransitionAssociation < StandardError; end
+
+  class GuardFailedError < StandardError
+    attr_reader :guard_name
+
+    def initialize(message, guard_name: nil)
+      @guard_name = guard_name
+      super(message)
+    end
+  end
 
   class UnserializedMetadataError < StandardError
     def initialize(transition_class_name)

--- a/lib/statesman/guard.rb
+++ b/lib/statesman/guard.rb
@@ -3,10 +3,17 @@ require_relative "exceptions"
 
 module Statesman
   class Guard < Callback
+    attr_reader :name
+
+    def initialize(options = { from: nil, to: nil, callback: nil })
+      @name = options[:name]
+      super
+    end
+
     def call(*args)
       unless super(*args)
-        raise GuardFailedError,
-              "Guard on transition from: '#{from}' to '#{to}' returned false"
+        raise GuardFailedError.new("Guard on transition from: '#{from}' to " \
+                                   "'#{to}' returned false", guard_name: name)
       end
     end
   end

--- a/spec/statesman/guard_spec.rb
+++ b/spec/statesman/guard_spec.rb
@@ -16,7 +16,27 @@ describe Statesman::Guard do
 
     context "error" do
       let(:callback) { -> { false } }
-      specify { expect { call }.to raise_error(Statesman::GuardFailedError) }
+
+      it "raises a GuardFailedError with no name" do
+        expect { call }.to raise_error do |error|
+          expect(error).to be_a(Statesman::GuardFailedError)
+          expect(error.guard_name).to be_nil
+        end
+      end
+
+      context "when the guard has a name specified" do
+        let(:guard) do
+          Statesman::Guard.new(from: nil, to: nil, callback: callback,
+                               name: :arbitrary_name)
+        end
+
+        it "raises a GuardFailedError with the guard's name accessible" do
+          expect { call }.to raise_error do |error|
+            expect(error).to be_a(Statesman::GuardFailedError)
+            expect(error.guard_name).to be(:arbitrary_name)
+          end
+        end
+      end
     end
   end
 end

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -615,8 +615,12 @@ describe Statesman::Machine do
 
     context "when it is unsuccesful" do
       before do
+        guard_failed_error = Statesman::GuardFailedError.new(
+          "Guard on transition from: 'active' to 'inactive' returned false"
+        )
+
         allow(instance).to receive(:transition_to!).
-          and_raise(Statesman::GuardFailedError)
+          and_raise(guard_failed_error)
       end
       it { is_expected.to be_falsey }
     end


### PR DESCRIPTION
Guards allow you to prevent a transition from occuring under certain conditions defined in your state machine.

When calling `Machine#transition_to!`, a `Statesman::GuardFailedError` is raised when a guard fails (i.e. returns false). As noted in #254, it is not currently possible to tell *which* Guard failed.

If you wanted to be able to different things depending on why you couldn't transition (e.g. returning a specific error response in an API), this means that you'll probably end up duplicating code, and at the very least, performing your guard operation twice, which could be expensive:

```ruby
return reactivation_not_permitted_error unless subscription.product.reactivation_permitted?
return no_payment_method_error unless subscription.user.payment_method.present?

subscription.transition_to!(:active)
render @subscription
```

This exposes a `guard_name` on `Statesman::GuardFailedError` which can be inspected and used to take relevant actions without performing the guarding operation twice.

```ruby
begin
  subscription.transition_to!(:active)
rescue Statesman::GuardFailedError => e
  return reactivation_not_permitted_error if e.guard_name == :reactivation_must_be_permitted
  return no_payment_method_error if e.guard_name == :payment_method_required
end

render @subscription
```