### PR TITLE
allowed_transitions? accept metadata to pass to guards

### DIFF
--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -189,9 +189,9 @@ module Statesman
       states.flatten.any? { |state| current_state == state.to_s }
     end
 
-    def allowed_transitions
+    def allowed_transitions(metadata = {})
       successors_for(current_state).select do |state|
-        can_transition_to?(state)
+        can_transition_to?(state, metadata)
       end
     end
 


### PR DESCRIPTION
Internally, allowed_transitions? uses can_transition_to? to call all guards on a transition to check it's feasability.

While you can pass metadata into can_transition_to? for the guards to use, you don't have the possibility on allowed_transitions?

This allows you to list the allowed transitions given a metadata context (we use metadata in our transitions heavily to add context of the change)

There are no breaking changes.