### PR TITLE
Enable inheritance between state machine classes

### DIFF
--- a/lib/statesman.rb
+++ b/lib/statesman.rb
@@ -1,10 +1,11 @@
 module Statesman
-  autoload :Config,     'statesman/config'
-  autoload :Machine,    'statesman/machine'
-  autoload :Callback,   'statesman/callback'
-  autoload :Guard,      'statesman/guard'
-  autoload :Utils,      'statesman/utils'
-  autoload :Version,    'statesman/version'
+  autoload :Config,               'statesman/config'
+  autoload :Machine,              'statesman/machine'
+  autoload :Callback,             'statesman/callback'
+  autoload :Guard,                'statesman/guard'
+  autoload :Utils,                'statesman/utils'
+  autoload :Version,              'statesman/version'
+  autoload :MachineInheritance,   'statesman/machine_inheritance'
   module Adapters
     autoload :Memory,       "statesman/adapters/memory"
     autoload :ActiveRecord, "statesman/adapters/active_record"

--- a/lib/statesman/machine_inheritance.rb
+++ b/lib/statesman/machine_inheritance.rb
@@ -1,0 +1,47 @@
+module Statesman
+  module MachineInheritance
+    def self.included(receiver)
+      receiver.extend ClassMethods
+    end
+
+    module ClassMethods
+      def inherit_from(state_machine)
+        inherit_initial_state_from  state_machine
+        inherit_states_from         state_machine
+        inherit_transitions_from    state_machine
+        inherit_callbacks_from      state_machine
+      end
+
+      def inherit_initial_state_from(state_machine)
+        state state_machine.initial_state, initial: true
+      end
+
+      def inherit_states_from(state_machine)
+        state_machine.states.each do |state_to_inherit|
+          next if states.include? state_to_inherit
+          state state_to_inherit
+        end
+      end
+
+      def inherit_transitions_from(state_machine)
+        state_machine.successors.each do |from, to|
+          transition from: from, to: to
+        end
+      end
+
+      def inherit_callbacks_from(state_machine)
+        state_machine.callbacks.each do |callback_type, callbacks|
+          callbacks.each do |callback|
+            add_callback(
+              callback_type: callback_type,
+              callback_class: callback.class,
+              from: callback.from,
+              to: callback.to,
+              &callback.callback
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/statesman/machine_inheritance_spec.rb
+++ b/spec/statesman/machine_inheritance_spec.rb
@@ -1,0 +1,108 @@
+require "spec_helper"
+
+describe Statesman::MachineInheritance do
+  describe "state machine inheritance module" do
+    let!(:parent_state_machine) { Class.new.include(Statesman::Machine) }
+    let!(:child_state_machine) { Class.new.include(Statesman::Machine) }
+
+    let(:initial_state) { "zeroth_state" }
+    let(:other_states) { %w[first_state second_state third_state] }
+    let(:all_states) { ([initial_state] + other_states) }
+
+    before do
+      parent_state_machine.state(initial_state, initial: true)
+      other_states.each { |state| parent_state_machine.state state }
+
+      child_state_machine.include(described_class)
+    end
+
+    context "enables state inheritance from the parent state machine" do
+      context "for initial state" do
+        it do
+          expect(child_state_machine.initial_state).to be(nil)
+
+          child_state_machine.inherit_initial_state_from parent_state_machine
+          expect(child_state_machine.initial_state).to eql(initial_state)
+        end
+      end
+
+      context "for other states" do
+        it do
+          expect(child_state_machine.states).to eql([])
+
+          child_state_machine.inherit_states_from parent_state_machine
+          expect(child_state_machine.states).to eql(all_states)
+        end
+      end
+
+      context "but does not duplicate already existing states" do
+        before { child_state_machine.state :first_state }
+
+        it do
+          child_state_machine.inherit_states_from parent_state_machine
+          expect(child_state_machine.states.count("first_state")).to be(1)
+        end
+      end
+    end
+
+    context "enables transition inheritance from the parent state machine" do
+      before do
+        child_state_machine.inherit_states_from parent_state_machine
+        parent_state_machine.transition from: initial_state, to: other_states
+      end
+
+      it do
+        expect(child_state_machine.successors).to eql({})
+
+        child_state_machine.inherit_transitions_from parent_state_machine
+        expect(child_state_machine.successors).
+          to eql(initial_state => other_states)
+      end
+    end
+
+    context "enables callback inheritance from the parent_state_machine" do
+      before do
+        child_state_machine.inherit_states_from parent_state_machine
+        parent_state_machine.transition from: initial_state, to: other_states
+
+        child_state_machine_callbacks = child_state_machine.callbacks
+        expect(child_state_machine_callbacks[:before]).to eql([])
+        expect(child_state_machine_callbacks[:after]).to eql([])
+        expect(child_state_machine_callbacks[:guards]).to eql([])
+      end
+
+      context "for 'guards'" do
+        before do
+          parent_state_machine.guard_transition { true }
+        end
+
+        it do
+          child_state_machine.inherit_callbacks_from parent_state_machine
+          expect(child_state_machine.callbacks[:guards].length).to be(1)
+        end
+      end
+
+      context "for 'before' callbacks" do
+        before do
+          parent_state_machine.before_transition { true }
+        end
+
+        it do
+          child_state_machine.inherit_callbacks_from parent_state_machine
+          expect(child_state_machine.callbacks[:before].length).to be(1)
+        end
+      end
+
+      context "for 'after' callbacks" do
+        before do
+          parent_state_machine.after_transition { true }
+        end
+
+        it do
+          child_state_machine.inherit_callbacks_from parent_state_machine
+          expect(child_state_machine.callbacks[:after].length).to be(1)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In order to use a state machine for tracking the various states of your application object, Statesman requires that you implement state machine classes. These classes are expected to `include` the `Statesman::Machine` module and make use of its class methods to define a  set of valid states, transitions and callbacks.

Depending on the application domain, it might be required that you implement different state machine classes for the same object based on its type. As these classes are bound to share some states, transitions and/or callbacks, this inherently results in duplicating the code which defines these states, transitions and/or callbacks in each of the state machine classes.

Since the calls to define the states, transitions and callbacks of a state machine class are executed when Ruby loads the file containing the class, it is not possible to use Ruby's inbuilt inheritance mechanism to share these definitions between classes.

Here, we introduce a Module that facilitates the sharing of such definitions between state machine classes. This can be included in any state machine class and its functions can be invoked at load time to inherit the definitions of states, transitions and callbacks from another state machine class.