### PR TITLE
Bump version to v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+## v3.2.0, 27 November 2017
+
+- Allow specifying metadata with `Machine#allowed_transitions` (patch by [@vvondra](https://github.com/vvondra))
+
 ## v3.1.0, 1 September 2017
 
 - Add support for Rails 5.0.x and 5.1.x (patch by [@kenchan0130](https://github.com/kenchan0130) and [@timrogers](https://github.com/timrogers))

--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,3 +1,3 @@
 module Statesman
-  VERSION = "3.1.0".freeze
+  VERSION = "3.2.0".freeze
 end

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -453,12 +453,22 @@ describe Statesman::Machine do
       it { is_expected.to eq(['z']) }
 
       context "guarded using metadata" do
-        before { machine.guard_transition(to: :z)  { |_, _, metadata | metadata[:some] == :metadata } }
+        before do
+          machine.guard_transition(to: :z) do |_, _, metadata|
+            metadata[:some] == :metadata
+          end
+        end
+
         it { is_expected.to eq(['z']) }
       end
 
       context "excluded by guard using metadata" do
-        before { machine.guard_transition(to: :z)  { |_, _, metadata | metadata[:some] != :metadata } }
+        before do
+          machine.guard_transition(to: :z) do |_, _, metadata|
+            metadata[:some] != :metadata
+          end
+        end
+
         it { is_expected.to eq([]) }
       end
     end
@@ -529,12 +539,22 @@ describe Statesman::Machine do
       end
 
       context "but it has a failing guard based on metadata" do
-        before { machine.guard_transition(to: :y)  { |_, _, metadata | metadata[:some] != :metadata } }
+        before do
+          machine.guard_transition(to: :y) do |_, _, metadata|
+            metadata[:some] != :metadata
+          end
+        end
+
         it { is_expected.to be_falsey }
       end
 
       context "and has a passing guard based on metadata" do
-        before { machine.guard_transition(to: :y)  { |_, _, metadata | metadata[:some] == :metadata } }
+        before do
+          machine.guard_transition(to: :y) do |_, _, metadata|
+            metadata[:some] == :metadata
+          end
+        end
+
         it { is_expected.to be_truthy }
       end
     end


### PR DESCRIPTION
This commit bumps the gem's version to v3.2.0, and adds the latest
changes to the changelog:

- Allow specifying metadata with `Machine#allowed_transitions`
(patch by [@vvondra](https://github.com/vvondra))

I've omitted the other [changes since v3.1.0](https://github.com/gocardless/statesman/compare/v3.1.0...master) since they only affect the README, code style and development dependencies.