### PR TITLE
Fix name spacing error in ActiveRecord adapter

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -88,7 +88,7 @@ module Statesman
 
       def unset_old_most_recent
         most_recent = transitions_for_parent.where(most_recent: true)
-        updated_at = if ActiveRecord::Base.default_timezone == :utc
+        updated_at = if ::ActiveRecord::Base.default_timezone == :utc
                        Time.now.utc
                      else
                        Time.now


### PR DESCRIPTION
The active record adapter is currently erroring with `uninitialized constant Statesman::Adapters::ActiveRecord::Base` due to 61f0e52.

It looks like CI has stopped running for this repo - the badge is linking to a 404 page.