### PR TITLE
Update Rubocop exceptions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,3 +15,7 @@ Metrics/BlockLength:
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
   Max: 107
+
+# Offense count: 1
+Lint/AmbiguousBlockAssociation:
+  Enabled: false


### PR DESCRIPTION
We want to allow rspec change blocks so disabling this test
makes sense.