### PR TITLE
Fix time dependant test.

### DIFF
--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "timecop"
 require "statesman/adapters/shared_examples"
 require "statesman/exceptions"
 
@@ -158,7 +159,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
         end
 
         it "touches the previous transition's updated_at timestamp" do
-          expect { create }.
+          expect { Timecop.freeze(Time.now + 5.seconds) { create } }.
             to change { previous_transition.reload.updated_at }
         end
 

--- a/statesman.gemspec
+++ b/statesman.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.3.0"
   spec.add_development_dependency "rubocop",               "~> 0.51.0"
   spec.add_development_dependency "sqlite3",               "~> 1.3"
+  spec.add_development_dependency "timecop",               "~> 0.9.1"
 end


### PR DESCRIPTION
Mysql does not seem to have enough precision in timestamp to record the
difference between two updates in the tests. Force the update to occur
seconds into the future to capture the change.