### PR TITLE
Use gc_ruboconfig from RubyGems, not rubconfig from Git

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,9 +5,3 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 2.2
-
-# This currently raises a false positive on date format strings, e.g. `lib/generators/
-# statesman/generator_helpers.rb:16`. Re-enable this once
-# https://github.com/bbatsov/rubocop/pull/5230 is merged.
-Style/FormatStringToken:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 inherit_gem:
-  ruboconfig: rubocop.yml
+  gc_ruboconfig: rubocop.yml
 
 AllCops:
   TargetRubyVersion: 2.2

--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,14 @@ source 'https://rubygems.org'
 gemspec
 
 gem "rails", "~> #{ENV['RAILS_VERSION']}" if ENV["RAILS_VERSION"]
-gem "ruboconfig", git: "https://github.com/gocardless/ruboconfig", tag: "v1.2.0"
 
 group :development do
   gem "mongoid", ">= 3.1" unless ENV["EXCLUDE_MONGOID"]
 
   # test/unit is no longer bundled with Ruby 2.2, but required by Rails
   gem "test-unit", "~> 3.0" if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2.0")
+end
+
+group :development, :test do
+  gem "gc_ruboconfig", "~> 2.0.0"
 end


### PR DESCRIPTION
This also re-enables the `Style/FormatStringToken` cop, since this will also update Rubocop to the latest version where this cop is no longer broken.