### PR TITLE
Adds ActiveSupport::StringInquirer-like behaviour for states.

### DIFF
--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -232,6 +232,18 @@ module Statesman
       false
     end
 
+    def respond_to_missing?(method_name, include_private = false)
+      method_name[-1] == "?" && self.class.states.include?(method_name) || super
+    end
+
+    def method_missing(method_name, *args, &block)
+      if method_name[-1] == "?" && self.class.states.include?(method_name[0..-2])
+        current_state == method_name[0..-2]
+      else
+        super
+      end
+    end
+
     private
 
     def adapter_class(transition_class)

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -429,6 +429,24 @@ describe Statesman::Machine do
     end
   end
 
+  describe "#state?" do
+    before { machine.state(:pending, initial: true) }
+    before { machine.state(:active) }
+    subject(:instance) { machine.new(my_model) }
+
+    context "when called with a valid state" do
+      specify { expect(instance.pending?).to be_truthy }
+      specify { expect(instance.active?).to be_falsey }
+    end
+
+    context "when called with a state that does't exist" do
+      it "raises an error" do
+        expect { machine.inactive? }.
+          to raise_error(NoMethodError)
+      end
+    end
+  end
+
   describe "#allowed_transitions" do
     before do
       machine.class_eval do


### PR DESCRIPTION
Sometimes it's more convenient to have inquirer methods for known states, rather than defining methods manually for all of them using `#in_state?`.

For example, a model with states `[:pending, :active, :inactive]` may need to have defined:
```ruby
def pending?
  in_state?("pending")
end

def active?
  in_state?("active")
end

def inactive?
  in_state?("inactive")
end
```
With this changes, these methods won't need to be explicitly defined on the model.

This uses similar `#method_missing` and `#respond_to_missing?` overrides as the official [ActiveSupport::StringInquirer](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/string_inquirer.rb), but also makes sure to check the model's existing states as well.