### PR TITLE
v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.4.0, 12 February 2018
+
+- When unsetting the `most_recent` flag during a transition, don't assume that transitions have an `updated_at` attribute, but rather allow the "updated timestamp column" to be re-configured or disabled entirely (patch by [@timrogers](https://github.com/timrogers))
+
 ## v3.3.0, 5 January 2018
 
 - Touch `updated_at` on transitions when unsetting `most_recent` flag (patch by [@NGMarmaduke](https://github.com/NGMarmaduke))

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ protection.
 To get started, just add Statesman to your `Gemfile`, and then run `bundle`:
 
 ```ruby
-gem 'statesman', '~> 3.3.0'
+gem 'statesman', '~> 3.4.0'
 ```
 
 ## Usage

--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,3 +1,3 @@
 module Statesman
-  VERSION = "3.3.0".freeze
+  VERSION = "3.4.0".freeze
 end


### PR DESCRIPTION
- When unsetting the `most_recent` flag during a transition, don't assume that transitions have an `updated_at` attribute, but rather allow the "updated timestamp column" to be re-configured or disabled entirely (patch by [@timrogers](https://github.com/timrogers))