### PR TITLE
Support ActiveRecord transitions which don't include Statesman::Adapters::ActiveRecordTransition

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Order.not_in_state(:checking_out) # => [#<Order id: "123">]
 
 By default Statesman stores transition history in memory only. It can be
 persisted by configuring Statesman to use a different adapter. For example,
-ActiveRecord within Rails:
+for ActiveRecord within Rails:
 
 `config/initializers/statesman.rb`:
 
@@ -136,6 +136,10 @@ Generate the transition model:
 ```bash
 $ rails g statesman:active_record_transition Order OrderTransition
 ```
+
+Your transition class should
+`include Statesman::Adapters::ActiveRecordTransition` if you're using the
+ActiveRecord adapter.
 
 If you're using the ActiveRecord adapter and decide not to include the default
 `updated_at` column in your transition table, you'll need to configure the
@@ -178,8 +182,12 @@ or 5. To do that
   t.json :metadata, default: {}
   ```
 
-* Remove `include Statesman::Adapters::ActiveRecordTransition` statement from your
-  transition model
+* Remove the `include Statesman::Adapters::ActiveRecordTransition` statement from
+  your transition model. (If you want to customise your transition class's "updated
+  timestamp column", as described above, you should define a
+  `.updated_timestamp_column` method on your class and return the name of the column
+  as a symbol, or `nil` if you don't want to record an updated timestamp on
+  transitions.)
 
 ## Configuration
 

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -163,6 +163,19 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
             to(change { previous_transition.reload.updated_at })
         end
 
+        context "for a transition class without an updated timestamp column attribute" do
+          let!(:adapter) do
+            described_class.new(MyActiveRecordModelTransitionWithoutInclude,
+                                model,
+                                observer)
+          end
+
+          it "defaults to touching the previous transition's updated_at timestamp" do
+            expect { Timecop.freeze(Time.now + 5.seconds) { create } }.
+              to(change { previous_transition.reload.updated_at })
+          end
+        end
+
         context "with a custom updated timestamp column set" do
           around do |example|
             MyActiveRecordModelTransition.updated_timestamp_column.tap do |original_value|

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -40,6 +40,13 @@ class MyActiveRecordModelTransition < ActiveRecord::Base
   serialize :metadata, JSON
 end
 
+class MyActiveRecordModelTransitionWithoutInclude < ActiveRecord::Base
+  self.table_name = "my_active_record_model_transitions"
+
+  belongs_to :my_active_record_model
+  serialize :metadata, JSON
+end
+
 class CreateMyActiveRecordModelMigration < MIGRATION_CLASS
   def change
     create_table :my_active_record_models do |t|


### PR DESCRIPTION
In #306, we made the "updated timestamp column" for a transition configurable through a `class_attribute` on `Statesman::Adapters::ActiveRecordTransition`, which is generally `include`d on transition classes.

However, not all transition classes include this module, and indeed we have [advised][1] in the README not to include it when using a PostgreSQL JSON column type for metadata, as pointed out by #309.

This leads to an exception like the following when trying to perform a transition:

```
NoMethodError: undefined method `updated_timestamp_column' for #<Class:0x00007fdd2ade07b0>
```

This fixes the issue by defaulting to using `:updated_at` as before if the transition class doesn't have an `.updated_timestamp_column` method defined.

As a follow-up action, it'd be nice to get all transitions including the module to have a more consistent and friendly base for future improvements to Statesman, as discussed in the [issue comments][2]. This, however, would be a breaking change and should be introduced separately after more though.

Fixes #309.

[1]: https://github.com/gocardless/statesman#using-postgresql-json-column
[2]: https://github.com/gocardless/statesman/issues/309#issuecomment-365336286