### PR TITLE
Use empty hash string for metadata default value in both Rails 4 and 5

### DIFF
--- a/lib/generators/statesman/generator_helpers.rb
+++ b/lib/generators/statesman/generator_helpers.rb
@@ -9,7 +9,7 @@ module Statesman
     end
 
     def migration_class_name
-      klass.gsub(/::/, "").pluralize
+      klass.demodulize.pluralize
     end
 
     def next_migration_number

--- a/lib/generators/statesman/generator_helpers.rb
+++ b/lib/generators/statesman/generator_helpers.rb
@@ -44,9 +44,5 @@ module Statesman
     def database_supports_partial_indexes?
       Statesman::Adapters::ActiveRecord.database_supports_partial_indexes?
     end
-
-    def metadata_default_value
-      Utils.rails_5_or_higher? ? "{}" : "{}".inspect
-    end
   end
 end

--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -2,7 +2,7 @@ class Create<%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveR
   def change
     create_table :<%= table_name %> do |t|
       t.string :to_state, null: false
-      t.text :metadata<%= ", default: #{metadata_default_value}" unless mysql? %>
+      t.text :metadata<%= ", default: \"{}\"" unless mysql? %>
       t.integer :sort_key, null: false
       t.integer :<%= parent_id %>, null: false
       t.boolean :most_recent<%= ", null: false" if database_supports_partial_indexes? %>

--- a/lib/generators/statesman/templates/update_migration.rb.erb
+++ b/lib/generators/statesman/templates/update_migration.rb.erb
@@ -1,7 +1,7 @@
 class AddStatesmanTo<%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveRecord::Migration.current_version}]" if Statesman::Utils.rails_5_or_higher? %>
   def change
     add_column :<%= table_name %>, :to_state, :string, null: false
-    add_column :<%= table_name %>, :metadata, :text<%= ", default: #{metadata_default_value}" unless mysql? %>
+    add_column :<%= table_name %>, :metadata, :text<%= ", default: \"{}\"" unless mysql? %>
     add_column :<%= table_name %>, :sort_key, :integer, null: false
     add_column :<%= table_name %>, :<%= parent_id %>, :integer, null: false
     add_column :<%= table_name %>, :most_recent, null: false

--- a/spec/generators/statesman/active_record_transition_generator_spec.rb
+++ b/spec/generators/statesman/active_record_transition_generator_spec.rb
@@ -25,7 +25,7 @@ describe Statesman::ActiveRecordTransitionGenerator, type: :generator do
     end
 
     it "does not include the metadata default value when using MySQL", if: mysql? do
-      expect(migration).not_to contain(/default: "{}"/)
+      expect(migration).to_not contain(/default: "{}"/)
     end
 
     it "includes the metadata default value when other than MySQL", unless: mysql? do
@@ -34,13 +34,14 @@ describe Statesman::ActiveRecordTransitionGenerator, type: :generator do
 
     it "properly migrates the schema" do
       require file("db/migrate/#{time}_create_bacon_transitions.rb")
-      expect { CreateBaconTransitions.new.up }.not_to raise_error
+      expect { CreateBaconTransitions.new.up }.to_not raise_error
     end
   end
 
   describe "properly adds class names" do
-    before { run_generator %w[Yummy::Bacon Yummy::BaconTransition] }
     subject { file("app/models/yummy/bacon_transition.rb") }
+
+    before { run_generator %w[Yummy::Bacon Yummy::BaconTransition] }
 
     it { is_expected.to contain(/:bacon_transition/) }
     it { is_expected.to_not contain(%r{:yummy/bacon}) }
@@ -48,16 +49,18 @@ describe Statesman::ActiveRecordTransitionGenerator, type: :generator do
   end
 
   describe "properly formats without class names" do
-    before { run_generator %w[Bacon BaconTransition] }
     subject { file("app/models/bacon_transition.rb") }
+
+    before { run_generator %w[Bacon BaconTransition] }
 
     it { is_expected.to_not contain(/class_name:/) }
     it { is_expected.to contain(/class BaconTransition/) }
   end
 
   describe "it doesn't create any double-spacing" do
-    before { run_generator %w[Yummy::Bacon Yummy::BaconTransition] }
     subject { file("app/models/yummy/bacon_transition.rb") }
+
+    before { run_generator %w[Yummy::Bacon Yummy::BaconTransition] }
 
     it { is_expected.to_not contain(/\n\n\n/) }
   end

--- a/spec/generators/statesman/active_record_transition_generator_spec.rb
+++ b/spec/generators/statesman/active_record_transition_generator_spec.rb
@@ -8,6 +8,8 @@ describe Statesman::ActiveRecordTransitionGenerator, type: :generator do
   end
 
   describe "creates a migration" do
+    extend Statesman::GeneratorHelpers
+
     subject(:migration) { file("db/migrate/#{time}_create_bacon_transitions.rb") }
 
     before do
@@ -20,6 +22,14 @@ describe Statesman::ActiveRecordTransitionGenerator, type: :generator do
 
     it "includes a foreign key" do
       expect(migration).to contain("add_foreign_key :bacon_transitions, :bacons")
+    end
+
+    it "does not include the metadata default value when using MySQL", if: mysql? do
+      expect(migration).not_to contain(/default: "{}"/)
+    end
+
+    it "includes the metadata default value when other than MySQL", unless: mysql? do
+      expect(migration).to contain(/default: "{}"/)
     end
   end
 

--- a/spec/generators/statesman/active_record_transition_generator_spec.rb
+++ b/spec/generators/statesman/active_record_transition_generator_spec.rb
@@ -31,6 +31,11 @@ describe Statesman::ActiveRecordTransitionGenerator, type: :generator do
     it "includes the metadata default value when other than MySQL", unless: mysql? do
       expect(migration).to contain(/default: "{}"/)
     end
+
+    it "properly migrates the schema" do
+      require file("db/migrate/#{time}_create_bacon_transitions.rb")
+      expect { CreateBaconTransitions.new.up }.not_to raise_error
+    end
   end
 
   describe "properly adds class names" do

--- a/spec/generators/statesman/migration_generator_spec.rb
+++ b/spec/generators/statesman/migration_generator_spec.rb
@@ -32,7 +32,7 @@ describe Statesman::MigrationGenerator, type: :generator do
     it { is_expected.to contain(/null: false/) }
 
     it "does not include the metadata default value when using MySQL", if: mysql? do
-      expect(migration).not_to contain(/default: "{}"/)
+      expect(migration).to_not contain(/default: "{}"/)
     end
 
     it "includes the metadata default value when other than MySQL", unless: mysql? do
@@ -51,7 +51,7 @@ describe Statesman::MigrationGenerator, type: :generator do
 
     it "properly migrates the schema" do
       require file("db/migrate/#{migration_number}_add_statesman_to_bacon_transitions.rb")
-      expect { AddStatesmanToBaconTransitions.new.up }.not_to raise_error
+      expect { AddStatesmanToBaconTransitions.new.up }.to_not raise_error
     end
   end
 end

--- a/spec/generators/statesman/migration_generator_spec.rb
+++ b/spec/generators/statesman/migration_generator_spec.rb
@@ -48,5 +48,10 @@ describe Statesman::MigrationGenerator, type: :generator do
       expect(migration).
         to contain("name: \"index_bacon_transitions_parent_most_recent\"")
     end
+
+    it "properly migrates the schema" do
+      require file("db/migrate/#{migration_number}_add_statesman_to_bacon_transitions.rb")
+      expect { AddStatesmanToBaconTransitions.new.up }.not_to raise_error
+    end
   end
 end

--- a/spec/generators/statesman/migration_generator_spec.rb
+++ b/spec/generators/statesman/migration_generator_spec.rb
@@ -8,6 +8,8 @@ describe Statesman::MigrationGenerator, type: :generator do
   end
 
   describe "the model contains the correct words" do
+    extend Statesman::GeneratorHelpers
+
     subject(:migration) do
       file(
         "db/migrate/#{migration_number}_add_statesman_to_bacon_transitions.rb",
@@ -28,6 +30,14 @@ describe Statesman::MigrationGenerator, type: :generator do
     it { is_expected.to contain(/:bacon_transition/) }
     it { is_expected.to_not contain(%r{:yummy/bacon}) }
     it { is_expected.to contain(/null: false/) }
+
+    it "does not include the metadata default value when using MySQL", if: mysql? do
+      expect(migration).not_to contain(/default: "{}"/)
+    end
+
+    it "includes the metadata default value when other than MySQL", unless: mysql? do
+      expect(migration).to contain(/default: "{}"/)
+    end
 
     it "names the sorting index appropriately" do
       expect(migration).

--- a/spec/generators/statesman/mongoid_transition_generator_spec.rb
+++ b/spec/generators/statesman/mongoid_transition_generator_spec.rb
@@ -4,16 +4,18 @@ require "generators/statesman/mongoid_transition_generator"
 
 describe Statesman::MongoidTransitionGenerator, type: :generator do
   describe "the model contains the correct words" do
-    before { run_generator %w[Yummy::Bacon Yummy::BaconTransition] }
     subject { file("app/models/yummy/bacon_transition.rb") }
+
+    before { run_generator %w[Yummy::Bacon Yummy::BaconTransition] }
 
     it { is_expected.to_not contain(%r{:yummy/bacon}) }
     it { is_expected.to contain(/class_name: 'Yummy::Bacon'/) }
   end
 
   describe "the model contains the correct words" do
-    before { run_generator %w[Bacon BaconTransition] }
     subject { file("app/models/bacon_transition.rb") }
+
+    before { run_generator %w[Bacon BaconTransition] }
 
     it { is_expected.to_not contain(/class_name:/) }
     it { is_expected.to_not contain(/CreateYummy::Bacon/) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require "statesman"
+require "generators/statesman/generator_helpers"
 require "sqlite3"
 require "mysql2"
 require "pg"

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -35,6 +35,7 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
     MyActiveRecordModel.send(:has_one, :other_active_record_model)
     OtherActiveRecordModel.send(:belongs_to, :my_active_record_model)
   end
+
   after { Statesman.configure { storage_adapter(Statesman::Adapters::Memory) } }
 
   let!(:model) do

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -10,6 +10,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
   end
 
   before { MyActiveRecordModelTransition.serialize(:metadata, JSON) }
+
   let(:observer) { double(Statesman::Machine, execute: nil) }
   let(:model) { MyActiveRecordModel.create(current_state: :pending) }
 
@@ -283,6 +284,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
 
       context "after then creating a new transition" do
         before { adapter.create(:y, :z, []) }
+
         it "retrieves the new transition from the database" do
           expect(adapter.last.to_state).to eq("z")
         end
@@ -329,6 +331,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
 
     context "with a pre-fetched transition history" do
       before { adapter.create(:x, :y) }
+
       before { model.my_active_record_model_transitions.load_target }
 
       it "doesn't query the database" do
@@ -347,6 +350,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
     before do
       MyNamespace::MyActiveRecordModelTransition.serialize(:metadata, JSON)
     end
+
     let(:observer) { double(Statesman::Machine, execute: nil) }
     let(:model) do
       MyNamespace::MyActiveRecordModel.create(current_state: :pending)

--- a/spec/statesman/adapters/mongoid_spec.rb
+++ b/spec/statesman/adapters/mongoid_spec.rb
@@ -6,6 +6,7 @@ require "mongoid"
 
 describe Statesman::Adapters::Mongoid, mongo: true do
   after { Mongoid.purge! }
+
   let(:observer) { double(Statesman::Machine, execute: nil) }
   let(:model) { MyMongoidModel.create(current_state: :pending) }
 
@@ -34,6 +35,7 @@ describe Statesman::Adapters::Mongoid, mongo: true do
 
     context "with a previously looked up transition" do
       before { adapter.create(:x, :y) }
+
       before { adapter.last }
 
       it "caches the transition" do
@@ -44,6 +46,7 @@ describe Statesman::Adapters::Mongoid, mongo: true do
 
       context "and a new transition" do
         before { adapter.create(:y, :z) }
+
         it "retrieves the new transition from the database" do
           expect(adapter.last.to_state).to eq("z")
         end

--- a/spec/statesman/adapters/shared_examples.rb
+++ b/spec/statesman/adapters/shared_examples.rb
@@ -52,6 +52,7 @@ shared_examples_for "an adapter" do |adapter_class, transition_class, options = 
 
       context "with a previous transition" do
         before { adapter.create(from, to) }
+
         its(:sort_key) { is_expected.to be(20) }
       end
     end
@@ -117,9 +118,11 @@ shared_examples_for "an adapter" do |adapter_class, transition_class, options = 
   end
 
   describe "#last" do
-    before { adapter.create(:x, :y) }
-    before { adapter.create(:y, :z) }
     subject { adapter.last }
+
+    before { adapter.create(:x, :y) }
+
+    before { adapter.create(:y, :z) }
 
     it { is_expected.to be_a(transition_class) }
     specify { expect(adapter.last.to_state.to_sym).to eq(:z) }

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -6,11 +6,14 @@ describe Statesman::Machine do
 
   describe ".state" do
     before { machine.state(:x) }
+
     before { machine.state(:y) }
+
     specify { expect(machine.states).to eq(%w[x y]) }
 
     context "initial" do
       before { machine.state(:x, initial: true) }
+
       specify { expect(machine.initial_state).to eq("x") }
 
       context "when an initial state is already defined" do
@@ -23,6 +26,12 @@ describe Statesman::Machine do
   end
 
   describe ".retry_conflicts" do
+    subject(:transition_state) do
+      described_class.retry_conflicts(retry_attempts) do
+        instance.transition_to(:y)
+      end
+    end
+
     before do
       machine.class_eval do
         state :x, initial: true
@@ -30,11 +39,6 @@ describe Statesman::Machine do
         state :z
         transition from: :x, to: :y
         transition from: :y, to: :z
-      end
-    end
-    subject(:transition_state) do
-      described_class.retry_conflicts(retry_attempts) do
-        instance.transition_to(:y)
       end
     end
 
@@ -358,6 +362,8 @@ describe Statesman::Machine do
   end
 
   describe "#current_state" do
+    subject { instance.current_state }
+
     before do
       machine.class_eval do
         state :x, initial: true
@@ -368,8 +374,6 @@ describe Statesman::Machine do
       end
     end
 
-    subject { instance.current_state }
-
     let(:instance) { machine.new(my_model) }
 
     context "with no transitions" do
@@ -378,6 +382,7 @@ describe Statesman::Machine do
 
     context "with multiple transitions" do
       before { instance.transition_to!(:y) }
+
       before { instance.transition_to!(:z) }
 
       it { is_expected.to eq("z") }
@@ -385,6 +390,8 @@ describe Statesman::Machine do
   end
 
   describe "#in_state?" do
+    subject { instance.in_state?(state) }
+
     before do
       machine.class_eval do
         state :x, initial: true
@@ -392,8 +399,6 @@ describe Statesman::Machine do
         transition from: :x, to: :y
       end
     end
-
-    subject { instance.in_state?(state) }
 
     let(:instance) { machine.new(my_model) }
 
@@ -449,6 +454,8 @@ describe Statesman::Machine do
   end
 
   describe "#allowed_transitions" do
+    subject { instance.allowed_transitions(metadata) }
+
     before do
       machine.class_eval do
         state :x, initial: true
@@ -459,8 +466,6 @@ describe Statesman::Machine do
       end
     end
 
-    subject { instance.allowed_transitions(metadata) }
-
     let(:instance) { machine.new(my_model) }
     let(:metadata) { { some: :metadata } }
 
@@ -470,6 +475,7 @@ describe Statesman::Machine do
 
     context "with one possible state" do
       before { instance.transition_to!(:y) }
+
       it { is_expected.to eq(["z"]) }
 
       context "guarded using metadata" do
@@ -495,6 +501,7 @@ describe Statesman::Machine do
 
     context "with no possible transitions" do
       before { instance.transition_to!(:z) }
+
       it { is_expected.to eq([]) }
     end
   end
@@ -511,6 +518,8 @@ describe Statesman::Machine do
   end
 
   describe "#can_transition_to?" do
+    subject { instance.can_transition_to?(new_state, metadata) }
+
     before do
       machine.class_eval do
         state :x, initial: true
@@ -520,8 +529,6 @@ describe Statesman::Machine do
         transition from: :y, to: :z
       end
     end
-
-    subject { instance.can_transition_to?(new_state, metadata) }
 
     let(:instance) { machine.new(my_model) }
     let(:metadata) { { some: :metadata } }
@@ -535,6 +542,7 @@ describe Statesman::Machine do
 
       context "with a terminal from state" do
         before { instance.transition_to!(:y) }
+
         let(:new_state) { :y }
 
         it { is_expected.to be_falsey }
@@ -560,6 +568,7 @@ describe Statesman::Machine do
 
       context "but it has a failing guard" do
         before { machine.guard_transition(to: :y) { false } }
+
         it { is_expected.to be_falsey }
       end
 
@@ -679,6 +688,7 @@ describe Statesman::Machine do
         expect(instance).to receive(:transition_to!).once.
           with(:some_state, metadata).and_return(:some_state)
       end
+
       it { is_expected.to be(:some_state) }
     end
 
@@ -687,6 +697,7 @@ describe Statesman::Machine do
         allow(instance).to receive(:transition_to!).
           and_raise(Statesman::GuardFailedError)
       end
+
       it { is_expected.to be_falsey }
     end
 

--- a/spec/support/generators_shared_examples.rb
+++ b/spec/support/generators_shared_examples.rb
@@ -7,6 +7,7 @@ TMP_GENERATOR_PATH = File.expand_path("generator-tmp", __dir__)
 shared_examples "a generator" do
   destination TMP_GENERATOR_PATH
   before { prepare_destination }
+
   let(:gen) { generator %w[Yummy::Bacon Yummy::BaconTransition] }
 
   it "invokes create_model_file method" do


### PR DESCRIPTION
fixes #313

This PR changes `Statesman::GeneratorHelpers#metadata_default_value` to return `\"{}\"` in both Rails 4 and 5 by `Strint#dump`.

`#metadata_default_value` returns `"{}"` when using Rails 5. This places the text `default: {}` to generated migration files. So if `{}` is passed to [`ActiveRecord::ConnectionAdapters::Quoting#_quote`](https://github.com/rails/rails/blob/375a4143cf5caeb6159b338be824903edfd62836/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L163-L179) when `bin/rails db:migrate`, it no longer accepts Hash and raises `TypeError`. It seems to avoid unintentional YAML producing.

ref: https://github.com/rails/rails/commit/aa31d21f5f4fc4d679e74a60f9df9706da7de373

I confirmed that this issue is reproduced with Rails 5.0.7, 5.1.6 and 5.2.0 and not reproduced in Rails 4.2.10.

<details>
<summary>Rails 4.2.10</summary>

```
$ bin/rails -v
Rails 4.2.10
$ bin/rails g statesman:active_record_transition Payment PaymentTransition
Running via Spring preloader in process 96164
      create  db/migrate/20180415142529_create_payment_transitions.rb
      create  app/models/payment_transition.rb
$ cat db/migrate/20180415142529_create_payment_transitions.rb
class CreatePaymentTransitions < ActiveRecord::Migration
  def change
    create_table :payment_transitions do |t|
      t.string :to_state, null: false
      t.text :metadata, default: "{}"
      t.integer :sort_key, null: false
      t.integer :payment_id, null: false
      t.boolean :most_recent, null: false

      # If you decide not to include an updated timestamp column in your transition
      # table, you'll need to configure the `updated_timestamp_column` setting in your
      # migration class.
      t.timestamps null: false
    end

    # Foreign keys are optional, but highly recommended
    add_foreign_key :payment_transitions, :payments

    add_index(:payment_transitions,
              [:payment_id, :sort_key],
              unique: true,
              name: "index_payment_transitions_parent_sort")
    add_index(:payment_transitions,
              [:payment_id, :most_recent],
              unique: true,
              where: 'most_recent',
              name: "index_payment_transitions_parent_most_recent")
  end
end
$ bin/rake db:migrate
Running via Spring preloader in process 96210
== 20180415142529 CreatePaymentTransitions: migrating =========================
-- create_table(:payment_transitions)
   -> 0.0017s
-- add_foreign_key(:payment_transitions, :payments)
   -> 0.0000s
-- add_index(:payment_transitions, [:payment_id, :sort_key], {:unique=>true, :name=>"index_payment_transitions_parent_sort"})
   -> 0.0007s
-- add_index(:payment_transitions, [:payment_id, :most_recent], {:unique=>true, :where=>"most_recent", :name=>"index_payment_transitions_parent_most_recent"})
   -> 0.0008s
== 20180415142529 CreatePaymentTransitions: migrated (0.0036s) ================

$ git diff
diff --git a/db/schema.rb b/db/schema.rb
index 001adb2..e45a6d6 100644
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.

-ActiveRecord::Schema.define(version: 20180415141825) do
+ActiveRecord::Schema.define(version: 20180415142529) do
+
+  create_table "payment_transitions", force: :cascade do |t|
+    t.string   "to_state",                   null: false
+    t.text     "metadata",    default: "{}"
+    t.integer  "sort_key",                   null: false
+    t.integer  "payment_id",                 null: false
+    t.boolean  "most_recent",                null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+  end
+
+  add_index "payment_transitions", ["payment_id", "most_recent"], name: "index_payment_transitions_parent_most_recent", unique: true, where: "most_recent"
+  add_index "payment_transitions", ["payment_id", "sort_key"], name: "index_payment_transitions_parent_sort", unique: true

   create_table "payments", force: :cascade do |t|
     t.datetime "created_at", null: false
```

</details>

<details>
<summary>Rails 5.0.7 (same issue occurs in Rails 5.1.6 and 5.2.0)</summary>

```
$ bin/rails -v
Rails 5.0.7
$ bin/rails g statesman:active_record_transition Payment PaymentTransition
Running via Spring preloader in process 96563
      create  db/migrate/20180415143025_create_payment_transitions.rb
      create  app/models/payment_transition.rb
$ cat db/migrate/20180415143025_create_payment_transitions.rb
class CreatePaymentTransitions < ActiveRecord::Migration[5.0]
  def change
    create_table :payment_transitions do |t|
      t.string :to_state, null: false
      t.text :metadata, default: {}
      t.integer :sort_key, null: false
      t.integer :payment_id, null: false
      t.boolean :most_recent, null: false

      # If you decide not to include an updated timestamp column in your transition
      # table, you'll need to configure the `updated_timestamp_column` setting in your
      # migration class.
      t.timestamps null: false
    end

    # Foreign keys are optional, but highly recommended
    add_foreign_key :payment_transitions, :payments

    add_index(:payment_transitions,
              [:payment_id, :sort_key],
              unique: true,
              name: "index_payment_transitions_parent_sort")
    add_index(:payment_transitions,
              [:payment_id, :most_recent],
              unique: true,
              where: 'most_recent',
              name: "index_payment_transitions_parent_most_recent")
  end
end

$ bin/rake db:migrate
Running via Spring preloader in process 96623
== 20180415143025 CreatePaymentTransitions: migrating =========================
-- create_table(:payment_transitions)
rake aborted!
StandardError: An error has occurred, this and all later migrations canceled:

can't quote Hash
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/quoting.rb:186:in `_quote'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/sqlite3/quoting.rb:27:in `_quote'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/quoting.rb:23:in `quote'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/quoting.rb:111:in `quote_default_expression'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/schema_creation.rb:17:in `quote_default_expression'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/schema_creation.rb:113:in `add_column_options!'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/sqlite3/schema_creation.rb:17:in `add_column_options!'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/schema_creation.rb:34:in `visit_ColumnDefinition'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/schema_creation.rb:45:in `block in visit_TableDefinition'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/schema_creation.rb:45:in `map'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/schema_creation.rb:45:in `visit_TableDefinition'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/schema_creation.rb:14:in `accept'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/schema_statements.rb:278:in `create_table'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:846:in `block in method_missing'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:815:in `block in say_with_time'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:815:in `say_with_time'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:835:in `method_missing'
/Users/kymmt/app/db/migrate/20180415143025_create_payment_transitions.rb:3:in `change'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:789:in `exec_migration'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:773:in `block (2 levels) in migrate'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:772:in `block in migrate'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/connection_pool.rb:398:in `with_connection'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:771:in `migrate'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:951:in `migrate'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:1232:in `block in execute_migration_in_transaction'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:1300:in `block in ddl_transaction'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `block in transaction'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/transaction.rb:189:in `within_new_transaction'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/connection_adapters/abstract/database_statements.rb:232:in `transaction'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/transactions.rb:211:in `transaction'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:1300:in `ddl_transaction'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:1231:in `execute_migration_in_transaction'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:1203:in `block in migrate_without_lock'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:1202:in `each'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:1202:in `migrate_without_lock'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:1152:in `migrate'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:1006:in `up'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/migration.rb:984:in `migrate'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/tasks/database_tasks.rb:163:in `migrate'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activerecord-5.0.7/lib/active_record/railties/databases.rake:58:in `block (2 levels) in <top (required)>'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.0.7/lib/active_support/dependencies.rb:287:in `load'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.0.7/lib/active_support/dependencies.rb:287:in `block in load'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.0.7/lib/active_support/dependencies.rb:259:in `load_dependency'
/Users/kymmt/app/vendor/bundle/ruby/2.5.0/gems/activesupport-5.0.7/lib/active_support/dependencies.rb:287:in `load'
```

</details>

<br>

`json` and `jsonb` types for Postgres allow to use `{}` in migration files, but I think it is better to use `"{}"` as the default value to be database-agnostic. And `String#inspect` is just for debugging, so I think it is better to use [`String#dump`](https://docs.ruby-lang.org/en/2.5.0/String.html#method-i-dump).
