### PR TITLE
Add SemVer compatibility badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ For our policy on compatibility with Ruby and Rails versions, see [COMPATIBILITY
 [![CircleCI](https://circleci.com/gh/gocardless/statesman.svg?style=svg)](https://circleci.com/gh/gocardless/statesman)
 [![Code Climate](https://codeclimate.com/github/gocardless/statesman.svg)](https://codeclimate.com/github/gocardless/statesman)
 [![Gitter](https://badges.gitter.im/join.svg)](https://gitter.im/gocardless/statesman?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=statesman&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=statesman&package-manager=bundler&version-scheme=semver)
 
 Statesman is an opinionated state machine library designed to provide a robust
 audit trail and data integrity. It decouples the state machine logic from the

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A statesmanlike state machine library.
 For our policy on compatibility with Ruby and Rails versions, see [COMPATIBILITY.md](docs/COMPATIBILITY.md).
 
 [![Gem Version](https://badge.fury.io/rb/statesman.svg)](http://badge.fury.io/rb/statesman)
-[![CircleCI](https://circleci.com/gh/gocardless/statesman.svg?style=svg)](https://circleci.com/gh/gocardless/statesman)
+[![CircleCI](https://circleci.com/gh/gocardless/statesman.svg?style=shield)](https://circleci.com/gh/gocardless/statesman)
 [![Code Climate](https://codeclimate.com/github/gocardless/statesman.svg)](https://codeclimate.com/github/gocardless/statesman)
 [![Gitter](https://badges.gitter.im/join.svg)](https://gitter.im/gocardless/statesman?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=statesman&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=statesman&package-manager=bundler&version-scheme=semver)


### PR DESCRIPTION
Would you folks be up for showing your SemVer compatibility in a badge on your readme? We've just added the ability to do that using data from the test-runs of all the pull requests Dependabot creates - what do you reckon?

Here's what the badge will look like, and where it will link to:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=statesman&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=statesman&package-manager=bundler&version-scheme=semver)

Any feedback super appreciated!