### PR TITLE
Make generators more rubocop friendly

### DIFF
--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -17,13 +17,13 @@ class Create<%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveR
     add_foreign_key :<%= table_name %>, :<%= parent_table_name %>
 
     add_index(:<%= table_name %>,
-              [:<%= parent_id %>, :sort_key],
+              %i(<%= parent_id %> sort_key),
               unique: true,
               name: "<%= index_name :parent_sort %>")
     add_index(:<%= table_name %>,
-              [:<%= parent_id %>, :most_recent],
+              %i(<%= parent_id %> most_recent),
               unique: true,
-              <%= "where: 'most_recent'," if database_supports_partial_indexes? %>
+              <%= 'where: "most_recent",' if database_supports_partial_indexes? %>
               name: "<%= index_name :parent_most_recent %>")
   end
 end

--- a/lib/generators/statesman/templates/update_migration.rb.erb
+++ b/lib/generators/statesman/templates/update_migration.rb.erb
@@ -8,7 +8,7 @@ class AddStatesmanTo<%= migration_class_name %> < ActiveRecord::Migration<%= "[#
     add_column :<%= table_name %>, :created_at, :datetime, null: false
     add_column :<%= table_name %>, :updated_at, :datetime, null: false
 
-    add_index :<%= table_name %>, [:<%= parent_id %>, :sort_key], unique: true, name: "<%= index_name :parent_sort  %>"
-    add_index :<%= table_name %>, [:<%= parent_id %>, :most_recent], unique: true, <%= "where: 'most_recent', " if database_supports_partial_indexes? %>name: "<%= index_name :parent_most_recent %>"
+    add_index :<%= table_name %>, %i(<%= parent_id %> sort_key), unique: true, name: "<%= index_name :parent_sort  %>"
+    add_index :<%= table_name %>, %i(<%= parent_id %> most_recent), unique: true, <%= 'where: "most_recent", ' if database_supports_partial_indexes? %>name: "<%= index_name :parent_most_recent %>"
   end
 end


### PR DESCRIPTION
- Statesman only support Ruby 2.2+, so we can use `%i(...)` syntax for symbol arrays
- Using single quotes and double quotes inconsistently was never necessary

Won't make the generators fit everyone's rubocop setup, but will mean they have a chance of fitting some people's.

Regen of #288 to try to fix CI.