### PR TITLE
Update CircleCI Mongo Image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
         environment:
           - RAILS_VERSION=4.2.9
           - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3.0.14
+      - image: circleci/mongo:3
     steps: *steps
   build-ruby241-rails-429-mysql:
     docker:
@@ -72,7 +72,7 @@ jobs:
         environment:
           - RAILS_VERSION=5.0.5
           - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3.0.14
+      - image: circleci/mongo:3
     steps: *steps
   build-ruby241-rails-505-mysql:
     docker:
@@ -108,7 +108,7 @@ jobs:
         environment:
           - RAILS_VERSION=5.1.3
           - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3.0.14
+      - image: circleci/mongo:3
     steps: *steps
   build-ruby241-rails-513-mysql:
     docker:
@@ -144,7 +144,7 @@ jobs:
         environment:
           - RAILS_VERSION=4.2.9
           - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3.0.14
+      - image: circleci/mongo:3
     steps: *steps
   build-ruby233-rails-429-mysql:
     docker:
@@ -180,7 +180,7 @@ jobs:
         environment:
           - RAILS_VERSION=5.0.5
           - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3.0.14
+      - image: circleci/mongo:3
     steps: *steps
   build-ruby233-rails-505-mysql:
     docker:
@@ -216,7 +216,7 @@ jobs:
         environment:
           - RAILS_VERSION=5.1.3
           - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3.0.14
+      - image: circleci/mongo:3
     steps: *steps
   build-ruby233-rails-513-mysql:
     docker:
@@ -252,7 +252,7 @@ jobs:
         environment:
           - RAILS_VERSION=4.2.9
           - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3.0.14
+      - image: circleci/mongo:3
     steps: *steps
   build-ruby227-rails-429-mysql:
     docker:
@@ -288,7 +288,7 @@ jobs:
         environment:
           - RAILS_VERSION=5.0.5
           - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3.0.14
+      - image: circleci/mongo:3
     steps: *steps
   build-ruby227-rails-505-mysql:
     docker:
@@ -324,7 +324,7 @@ jobs:
         environment:
           - RAILS_VERSION=5.1.3
           - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3.0.14
+      - image: circleci/mongo:3
     steps: *steps
   build-ruby227-rails-513-mysql:
     docker:

--- a/spec/generators/statesman/active_record_transition_generator_spec.rb
+++ b/spec/generators/statesman/active_record_transition_generator_spec.rb
@@ -24,8 +24,9 @@ describe Statesman::ActiveRecordTransitionGenerator, type: :generator do
   end
 
   describe "properly adds class names" do
-    before { run_generator %w[Yummy::Bacon Yummy::BaconTransition] }
     subject { file("app/models/yummy/bacon_transition.rb") }
+
+    before { run_generator %w[Yummy::Bacon Yummy::BaconTransition] }
 
     it { is_expected.to contain(/:bacon_transition/) }
     it { is_expected.to_not contain(%r{:yummy/bacon}) }
@@ -33,16 +34,18 @@ describe Statesman::ActiveRecordTransitionGenerator, type: :generator do
   end
 
   describe "properly formats without class names" do
-    before { run_generator %w[Bacon BaconTransition] }
     subject { file("app/models/bacon_transition.rb") }
+
+    before { run_generator %w[Bacon BaconTransition] }
 
     it { is_expected.to_not contain(/class_name:/) }
     it { is_expected.to contain(/class BaconTransition/) }
   end
 
   describe "it doesn't create any double-spacing" do
-    before { run_generator %w[Yummy::Bacon Yummy::BaconTransition] }
     subject { file("app/models/yummy/bacon_transition.rb") }
+
+    before { run_generator %w[Yummy::Bacon Yummy::BaconTransition] }
 
     it { is_expected.to_not contain(/\n\n\n/) }
   end

--- a/spec/generators/statesman/mongoid_transition_generator_spec.rb
+++ b/spec/generators/statesman/mongoid_transition_generator_spec.rb
@@ -4,16 +4,18 @@ require "generators/statesman/mongoid_transition_generator"
 
 describe Statesman::MongoidTransitionGenerator, type: :generator do
   describe "the model contains the correct words" do
-    before { run_generator %w[Yummy::Bacon Yummy::BaconTransition] }
     subject { file("app/models/yummy/bacon_transition.rb") }
+
+    before { run_generator %w[Yummy::Bacon Yummy::BaconTransition] }
 
     it { is_expected.to_not contain(%r{:yummy/bacon}) }
     it { is_expected.to contain(/class_name: 'Yummy::Bacon'/) }
   end
 
   describe "the model contains the correct words" do
-    before { run_generator %w[Bacon BaconTransition] }
     subject { file("app/models/bacon_transition.rb") }
+
+    before { run_generator %w[Bacon BaconTransition] }
 
     it { is_expected.to_not contain(/class_name:/) }
     it { is_expected.to_not contain(/CreateYummy::Bacon/) }

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -35,6 +35,7 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
     MyActiveRecordModel.send(:has_one, :other_active_record_model)
     OtherActiveRecordModel.send(:belongs_to, :my_active_record_model)
   end
+
   after { Statesman.configure { storage_adapter(Statesman::Adapters::Memory) } }
 
   let!(:model) do
@@ -107,20 +108,20 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
     end
 
     context "given multiple states" do
-      subject { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
+      subject(:not_in_state) { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
 
       it do
-        is_expected.to match_array([initial_state_model,
-                                    returned_to_initial_model])
+        expect(not_in_state).to match_array([initial_state_model,
+                                             returned_to_initial_model])
       end
     end
 
     context "given an array of states" do
-      subject { MyActiveRecordModel.not_in_state(%i[succeeded failed]) }
+      subject(:not_in_state) { MyActiveRecordModel.not_in_state(%i[succeeded failed]) }
 
       it do
-        is_expected.to match_array([initial_state_model,
-                                    returned_to_initial_model])
+        expect(not_in_state).to match_array([initial_state_model,
+                                             returned_to_initial_model])
       end
     end
   end

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -10,6 +10,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
   end
 
   before { MyActiveRecordModelTransition.serialize(:metadata, JSON) }
+
   let(:observer) { double(Statesman::Machine, execute: nil) }
   let(:model) { MyActiveRecordModel.create(current_state: :pending) }
 
@@ -277,12 +278,13 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
 
       it "caches the transition" do
         expect_any_instance_of(MyActiveRecordModel).
-          to receive(:my_active_record_model_transitions).never
+          to_not receive(:my_active_record_model_transitions)
         adapter.last
       end
 
       context "after then creating a new transition" do
         before { adapter.create(:y, :z, []) }
+
         it "retrieves the new transition from the database" do
           expect(adapter.last.to_state).to eq("z")
         end
@@ -297,7 +299,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
           alternate_adapter.create(:y, :z, [])
 
           expect_any_instance_of(MyActiveRecordModel).
-            to receive(:my_active_record_model_transitions).never
+            to_not receive(:my_active_record_model_transitions)
           expect(adapter.last.to_state).to eq("y")
         end
 
@@ -329,6 +331,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
 
     context "with a pre-fetched transition history" do
       before { adapter.create(:x, :y) }
+
       before { model.my_active_record_model_transitions.load_target }
 
       it "doesn't query the database" do
@@ -347,6 +350,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
     before do
       MyNamespace::MyActiveRecordModelTransition.serialize(:metadata, JSON)
     end
+
     let(:observer) { double(Statesman::Machine, execute: nil) }
     let(:model) do
       MyNamespace::MyActiveRecordModel.create(current_state: :pending)

--- a/spec/statesman/adapters/mongoid_spec.rb
+++ b/spec/statesman/adapters/mongoid_spec.rb
@@ -6,6 +6,7 @@ require "mongoid"
 
 describe Statesman::Adapters::Mongoid, mongo: true do
   after { Mongoid.purge! }
+
   let(:observer) { double(Statesman::Machine, execute: nil) }
   let(:model) { MyMongoidModel.create(current_state: :pending) }
 
@@ -34,16 +35,18 @@ describe Statesman::Adapters::Mongoid, mongo: true do
 
     context "with a previously looked up transition" do
       before { adapter.create(:x, :y) }
+
       before { adapter.last }
 
       it "caches the transition" do
         expect_any_instance_of(MyMongoidModel).
-          to receive(:my_mongoid_model_transitions).never
+          to_not receive(:my_mongoid_model_transitions)
         adapter.last
       end
 
       context "and a new transition" do
         before { adapter.create(:y, :z) }
+
         it "retrieves the new transition from the database" do
           expect(adapter.last.to_state).to eq("z")
         end

--- a/spec/statesman/adapters/shared_examples.rb
+++ b/spec/statesman/adapters/shared_examples.rb
@@ -52,6 +52,7 @@ shared_examples_for "an adapter" do |adapter_class, transition_class, options = 
 
       context "with a previous transition" do
         before { adapter.create(from, to) }
+
         its(:sort_key) { is_expected.to be(20) }
       end
     end
@@ -117,9 +118,11 @@ shared_examples_for "an adapter" do |adapter_class, transition_class, options = 
   end
 
   describe "#last" do
-    before { adapter.create(:x, :y) }
-    before { adapter.create(:y, :z) }
     subject { adapter.last }
+
+    before { adapter.create(:x, :y) }
+
+    before { adapter.create(:y, :z) }
 
     it { is_expected.to be_a(transition_class) }
     specify { expect(adapter.last.to_state.to_sym).to eq(:z) }

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -6,11 +6,14 @@ describe Statesman::Machine do
 
   describe ".state" do
     before { machine.state(:x) }
+
     before { machine.state(:y) }
+
     specify { expect(machine.states).to eq(%w[x y]) }
 
     context "initial" do
       before { machine.state(:x, initial: true) }
+
       specify { expect(machine.initial_state).to eq("x") }
 
       context "when an initial state is already defined" do
@@ -23,6 +26,12 @@ describe Statesman::Machine do
   end
 
   describe ".retry_conflicts" do
+    subject(:transition_state) do
+      described_class.retry_conflicts(retry_attempts) do
+        instance.transition_to(:y)
+      end
+    end
+
     before do
       machine.class_eval do
         state :x, initial: true
@@ -30,11 +39,6 @@ describe Statesman::Machine do
         state :z
         transition from: :x, to: :y
         transition from: :y, to: :z
-      end
-    end
-    subject(:transition_state) do
-      described_class.retry_conflicts(retry_attempts) do
-        instance.transition_to(:y)
       end
     end
 
@@ -358,6 +362,8 @@ describe Statesman::Machine do
   end
 
   describe "#current_state" do
+    subject { instance.current_state }
+
     before do
       machine.class_eval do
         state :x, initial: true
@@ -368,8 +374,6 @@ describe Statesman::Machine do
       end
     end
 
-    subject { instance.current_state }
-
     let(:instance) { machine.new(my_model) }
 
     context "with no transitions" do
@@ -378,6 +382,7 @@ describe Statesman::Machine do
 
     context "with multiple transitions" do
       before { instance.transition_to!(:y) }
+
       before { instance.transition_to!(:z) }
 
       it { is_expected.to eq("z") }
@@ -385,6 +390,8 @@ describe Statesman::Machine do
   end
 
   describe "#in_state?" do
+    subject { instance.in_state?(state) }
+
     before do
       machine.class_eval do
         state :x, initial: true
@@ -392,8 +399,6 @@ describe Statesman::Machine do
         transition from: :x, to: :y
       end
     end
-
-    subject { instance.in_state?(state) }
 
     let(:instance) { machine.new(my_model) }
 
@@ -449,6 +454,8 @@ describe Statesman::Machine do
   end
 
   describe "#allowed_transitions" do
+    subject { instance.allowed_transitions(metadata) }
+
     before do
       machine.class_eval do
         state :x, initial: true
@@ -459,8 +466,6 @@ describe Statesman::Machine do
       end
     end
 
-    subject { instance.allowed_transitions(metadata) }
-
     let(:instance) { machine.new(my_model) }
     let(:metadata) { { some: :metadata } }
 
@@ -470,6 +475,7 @@ describe Statesman::Machine do
 
     context "with one possible state" do
       before { instance.transition_to!(:y) }
+
       it { is_expected.to eq(["z"]) }
 
       context "guarded using metadata" do
@@ -495,6 +501,7 @@ describe Statesman::Machine do
 
     context "with no possible transitions" do
       before { instance.transition_to!(:z) }
+
       it { is_expected.to eq([]) }
     end
   end
@@ -511,6 +518,8 @@ describe Statesman::Machine do
   end
 
   describe "#can_transition_to?" do
+    subject(:can_transition_to?) { instance.can_transition_to?(new_state, metadata) }
+
     before do
       machine.class_eval do
         state :x, initial: true
@@ -520,8 +529,6 @@ describe Statesman::Machine do
         transition from: :y, to: :z
       end
     end
-
-    subject { instance.can_transition_to?(new_state, metadata) }
 
     let(:instance) { machine.new(my_model) }
     let(:metadata) { { some: :metadata } }
@@ -535,6 +542,7 @@ describe Statesman::Machine do
 
       context "with a terminal from state" do
         before { instance.transition_to!(:y) }
+
         let(:new_state) { :y }
 
         it { is_expected.to be_falsey }
@@ -548,7 +556,7 @@ describe Statesman::Machine do
 
         it "does not fire guard" do
           expect(guard_cb).to_not receive(:call)
-          is_expected.to be_falsey
+          expect(can_transition_to?).to be_falsey
         end
       end
     end
@@ -560,6 +568,7 @@ describe Statesman::Machine do
 
       context "but it has a failing guard" do
         before { machine.guard_transition(to: :y) { false } }
+
         it { is_expected.to be_falsey }
       end
 
@@ -679,6 +688,7 @@ describe Statesman::Machine do
         expect(instance).to receive(:transition_to!).once.
           with(:some_state, metadata).and_return(:some_state)
       end
+
       it { is_expected.to be(:some_state) }
     end
 
@@ -687,6 +697,7 @@ describe Statesman::Machine do
         allow(instance).to receive(:transition_to!).
           and_raise(Statesman::GuardFailedError)
       end
+
       it { is_expected.to be_falsey }
     end
 

--- a/spec/support/generators_shared_examples.rb
+++ b/spec/support/generators_shared_examples.rb
@@ -7,6 +7,7 @@ TMP_GENERATOR_PATH = File.expand_path("generator-tmp", __dir__)
 shared_examples "a generator" do
   destination TMP_GENERATOR_PATH
   before { prepare_destination }
+
   let(:gen) { generator %w[Yummy::Bacon Yummy::BaconTransition] }
 
   it "invokes create_model_file method" do


### PR DESCRIPTION
CircleCI has unpublished the version of mongo we where testing against, switching to `3` means we currently test against `3.6.7`

There are also a bunch of Rubocop failures which are fixed with autocorrect. 