### PR TITLE
Document most_recent_transition_join.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v3.5.0, 2 November 2018
+
+- Expose `most_recent_transition_join` - ActiveRecords `or` requires that both
+    sides of the query match up. Exposing this methods makes things easier if
+    one side of the `or` uses `in_state` or `not_in_state`. (patch by [@adambutler](https://github.com/adambutler))
+- Various Readme and CI related changes.
+
 ## v3.4.1, 14 February 2018 ❤️
 
 - Support ActiveRecord transition classes which don't include `Statesman::Adapters::ActiveRecordTransition`, and thus don't have a `.updated_timestamp_column` method (see #310 for further details) (patch by [@timrogers](https://github.com/timrogers))

--- a/README.md
+++ b/README.md
@@ -374,6 +374,17 @@ Returns all models currently in any of the supplied states.
 #### `Model.not_in_state(:state_1, :state_2, etc)`
 Returns all models not currently in any of the supplied states.
 
+
+### `Model.most_recent_transition_join`
+This joins the model to its most recent transition whatever that may be.
+We expose this method to ease use of ActiveRecord's `or` e.g
+
+```ruby
+Model.in_state(:state_1).or(
+  Model.most_recent_transition_join.where(model_field: 123)
+)
+```
+
 ## Frequently Asked Questions
 
 #### Storing the state on the model object

--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,3 +1,3 @@
 module Statesman
-  VERSION = "3.4.1".freeze
+  VERSION = "3.5.0".freeze
 end


### PR DESCRIPTION
Adds `most_recent_transition_join` to the Readme now that it is exposed. Update the version number in preparation for a release too.