### PR TITLE
Make after_commit work reliabliy inside nested transactions

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -161,6 +161,7 @@ module Statesman
     class ActiveRecordAfterCommitWrap
       def initialize
         @callback = Proc.new
+        @connection = ::ActiveRecord::Base.connection
       end
 
       # rubocop: disable Naming/PredicateName

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -78,14 +78,18 @@ module Statesman
           transition.save!
           @last_transition = transition
           @observer.execute(:after, from, to, transition)
-          ::ActiveRecord::Base.connection.add_transaction_record(
-            ActiveRecordAfterCommitWrap.new do
-              @observer.execute(:after_commit, from, to, transition)
-            end
-          )
+          add_after_commit_callback(from, to, transition)
         end
 
         transition
+      end
+
+      def add_after_commit_callback(from, to, transition)
+        ::ActiveRecord::Base.connection.add_transaction_record(
+          ActiveRecordAfterCommitWrap.new do
+            @observer.execute(:after_commit, from, to, transition)
+          end,
+        )
       end
 
       def transitions_for_parent

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -163,6 +163,12 @@ module Statesman
         @callback = Proc.new
       end
 
+      # rubocop: disable Naming/PredicateName
+      def has_transactional_callbacks?
+        true
+      end
+      # rubocop: enable Naming/PredicateName
+
       def committed!(*)
         @callback.call
       end
@@ -170,6 +176,11 @@ module Statesman
       def before_committed!(*); end
 
       def rolledback!(*); end
+
+      # Required for +transaction(requires_new: true)+
+      def add_to_transaction(*)
+        @connection.add_transaction_record(self)
+      end
     end
   end
 end


### PR DESCRIPTION
In the current implementation, after_commit callbacks are ran
immediately after the `ActiveRecord::Base.transaction` block,
which is not guaranteed to be after the transaction has been
committed to the database.

Speficially, if statesman code is running inside another transaction,
the after_commit block will be running prematurely.

This commit fixes that behavious by using ActiveRecord’s
add_transaction_record method (which is how after_commit
callbacks are implemented in Rails).

This issue was already reported in #281 in December 2017, but never fixed.

Here’s a blog post explaining this behaviour: https://dev.to/evilmartians/rails-aftercommit-everywhere--4j9g

A secondary side-effect of this behaviour is that if you schedule a background job from within the `after_commit: true` callback, it’s not guaranteed that the transition has been committed to the database yet, and the scheduled job might not run correctly.

This is a sample state machine exhibiting this behaviour:

```ruby
class OrderStateMachine
  include Statesman::Machine

  state :pending, initial: true
  state :placed

  transition from: :pending, to: :placed

  after_transition from: :pending, to: :placed do
    puts "after_transition(after_commit: false) callback"
  end

  after_transition from: :pending, to: :placed, after_commit: true do
    puts "after_transition(after_commit: true) callback"
  end
end
```

and a simple test case:

```ruby
ActiveRecord::Base.transaction do
  order = Order.first
  order.state_machine.transition_to! :placed
  raise
end
```

Without the patch, the after_commit callback will execute even if the transaction is rolled back:

```
irb(main):001:0> Runner.run
   (0.1ms)  BEGIN
  Order Load (0.5ms)  SELECT  "orders".* FROM "orders" ORDER BY "orders"."id" ASC LIMIT $1  [["LIMIT", 1]]
  OrderTransition Load (0.7ms)  SELECT  "order_transitions".* FROM "order_transitions" WHERE "order_transitions"."order_id" = $1 ORDER BY "order_transitions"."sort_key" DESC LIMIT $2  [["order_id", 1], ["LIMIT", 1]]
  OrderTransition Load (0.3ms)  SELECT  "order_transitions".* FROM "order_transitions" WHERE "order_transitions"."order_id" = $1 ORDER BY "order_transitions"."sort_key" DESC LIMIT $2  [["order_id", 1], ["LIMIT", 1]]
  OrderTransition Update All (2.9ms)  UPDATE "order_transitions" SET "most_recent" = FALSE, "updated_at" = '2019-02-03 18:57:18.133758' WHERE "order_transitions"."order_id" = $1 AND "order_transitions"."most_recent" = $2  [["order_id", 1], ["most_recent", true]]
  OrderTransition Create (23.3ms)  INSERT INTO "order_transitions" ("to_state", "sort_key", "order_id", "most_recent", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"  [["to_state", "placed"], ["sort_key", 10], ["order_id", 1], ["most_recent", true], ["created_at", "2019-02-03 18:57:18.138074"], ["updated_at", "2019-02-03 18:57:18.138074"]]
after_transition(after_commit: false) callback
after_transition(after_commit: true) callback
   (0.4ms)  ROLLBACK
Traceback (most recent call last):
        3: from (irb):1
        2: from app/models/runner.rb:3:in `run'
        1: from app/models/runner.rb:6:in `block in run'
RuntimeError ()
```

With the patch, only the `after_commit: false` callback will run:

```
   (0.2ms)  BEGIN
  Order Load (0.4ms)  SELECT  "orders".* FROM "orders" ORDER BY "orders"."id" ASC LIMIT $1  [["LIMIT", 1]]
  OrderTransition Load (0.6ms)  SELECT  "order_transitions".* FROM "order_transitions" WHERE "order_transitions"."order_id" = $1 ORDER BY "order_transitions"."sort_key" DESC LIMIT $2  [["order_id", 1], ["LIMIT", 1]]
  OrderTransition Load (0.3ms)  SELECT  "order_transitions".* FROM "order_transitions" WHERE "order_transitions"."order_id" = $1 ORDER BY "order_transitions"."sort_key" DESC LIMIT $2  [["order_id", 1], ["LIMIT", 1]]
  OrderTransition Update All (0.7ms)  UPDATE "order_transitions" SET "most_recent" = FALSE, "updated_at" = '2019-02-03 18:58:06.566445' WHERE "order_transitions"."order_id" = $1 AND "order_transitions"."most_recent" = $2  [["order_id", 1], ["most_recent", true]]
  OrderTransition Create (1.1ms)  INSERT INTO "order_transitions" ("to_state", "sort_key", "order_id", "most_recent", "created_at", "updated_at") VALUES ($1, $2, $3, $4, $5, $6) RETURNING "id"  [["to_state", "placed"], ["sort_key", 10], ["order_id", 1], ["most_recent", true], ["created_at", "2019-02-03 18:58:06.568712"], ["updated_at", "2019-02-03 18:58:06.568712"]]
after_transition(after_commit: false) callback
   (0.3ms)  ROLLBACK
Traceback (most recent call last):
        3: from (irb):1
        2: from app/models/runner.rb:3:in `run'
        1: from app/models/runner.rb:6:in `block in run'
RuntimeError ()
```