### PR TITLE
Pin bundler to 1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ references:
     - type: cache-restore
       key: statesman-{{ checksum "Gemfile" }}-{{ checksum "~/RAILS_VERSION.txt" }}
 
-    - run: gem install bundler
+    - run: gem install bundler -v 1.3
 
     - run: bundle install --path vendor/bundle
 

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -25,6 +25,7 @@ module Statesman
         elsif serialized && JSON_COLUMN_TYPES.include?(column_type)
           raise IncompatibleSerializationError, transition_class.name
         end
+
         @transition_class = transition_class
         @parent_model = parent_model
         @observer = observer
@@ -36,6 +37,7 @@ module Statesman
         create_transition(from.to_s, to.to_s, metadata)
       rescue ::ActiveRecord::RecordNotUnique => e
         raise TransitionConflictError, e.message if transition_conflict_error? e
+
         raise
       ensure
         @last_transition = nil

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -46,10 +46,10 @@ module Statesman
 
       def callbacks
         @callbacks ||= {
-          before:       [],
-          after:        [],
+          before: [],
+          after: [],
           after_commit: [],
-          guards:       [],
+          guards: [],
         }
       end
 

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -227,6 +227,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
             it "still has the old state" do
               allow(observer).to receive(:execute) do |phase|
                 next unless phase == :before
+
                 expect(
                   model.transitions.where(most_recent: true).first.to_state,
                 ).to eq("y")
@@ -240,6 +241,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
             it "still has the old state" do
               allow(observer).to receive(:execute) do |phase|
                 next unless phase == :after
+
                 expect(
                   model.transitions.where(most_recent: true).first.to_state,
                 ).to eq("z")


### PR DESCRIPTION
Pin bundler install to 1.3 to work with old Ruby/Rails versions