### PR TITLE
Test after_commit transactional integrity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v4.0.0, 22 February 2019
+
+- Forces Statesman to use a new transactions with `requires_new: true` (https://github.com/gocardless/statesman/pull/249)
+- Fixes an issue with `after_commit` transition blocks that where being
+    executed even if the transaction rolled back. ([patch](https://github.com/gocardless/statesman/pull/338) by [@matid](https://github.com/matid))
+
 ## v3.5.0, 2 November 2018
 
 - Expose `most_recent_transition_join` - ActiveRecords `or` requires that both

--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,3 +1,3 @@
 module Statesman
-  VERSION = "3.5.0".freeze
+  VERSION = "4.0.0".freeze
 end


### PR DESCRIPTION
Test case taken from the comments in https://github.com/gocardless/statesman/pull/338 to prevent a regression.