### PR TITLE
Add better support for mysql in `transition_conflict_error?` method

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,78 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
     steps: *steps
+  build-ruby262-rails-600-mongo:
+    docker:
+      - image: circleci/ruby:2.6.2-node
+        environment:
+          - RAILS_VERSION=6.0.0.beta3
+          - DATABASE_DEPENDENCY_PORT=27017
+      - image: circleci/mongo:3
+    steps: *steps
+  build-ruby262-rails-600-mysql:
+    docker:
+      - image: circleci/ruby:2.6.2-node
+        environment:
+          - RAILS_VERSION=6.0.0.beta3
+          - DATABASE_URL=mysql2://root@127.0.0.1/statesman_test
+          - EXCLUDE_MONGOID=true
+          - DATABASE_DEPENDENCY_PORT=3306
+      - image: circleci/mysql:5.7.18
+        environment:
+          - MYSQL_ALLOW_EMPTY_PASSWORD=true
+          - MYSQL_USER=root
+          - MYSQL_PASSWORD=
+          - MYSQL_DATABASE=statesman_test
+    steps: *steps
+  build-ruby262-rails-600-postgres:
+    docker:
+      - image: circleci/ruby:2.6.2-node
+        environment:
+          - RAILS_VERSION=6.0.0.beta3
+          - DATABASE_URL=postgres://postgres@localhost/statesman_test
+          - EXCLUDE_MONGOID=true
+          - DATABASE_DEPENDENCY_PORT=5432
+      - image: circleci/postgres:9.6
+        environment:
+          - POSTGRES_USER=postgres
+          - POSTGRES_DB=statesman_test
+    steps: *steps
+  build-ruby241-rails-523-mongo:
+    docker:
+      - image: circleci/ruby:2.4.1-node
+        environment:
+          - RAILS_VERSION=5.2.3
+          - DATABASE_DEPENDENCY_PORT=27017
+      - image: circleci/mongo:3
+    steps: *steps
+  build-ruby241-rails-523-mysql:
+    docker:
+      - image: circleci/ruby:2.4.1-node
+        environment:
+          - RAILS_VERSION=5.2.3
+          - DATABASE_URL=mysql2://root@127.0.0.1/statesman_test
+          - EXCLUDE_MONGOID=true
+          - DATABASE_DEPENDENCY_PORT=3306
+      - image: circleci/mysql:5.7.18
+        environment:
+          - MYSQL_ALLOW_EMPTY_PASSWORD=true
+          - MYSQL_USER=root
+          - MYSQL_PASSWORD=
+          - MYSQL_DATABASE=statesman_test
+    steps: *steps
+  build-ruby241-rails-523-postgres:
+    docker:
+      - image: circleci/ruby:2.4.1-node
+        environment:
+          - RAILS_VERSION=5.2.3
+          - DATABASE_URL=postgres://postgres@localhost/statesman_test
+          - EXCLUDE_MONGOID=true
+          - DATABASE_DEPENDENCY_PORT=5432
+      - image: circleci/postgres:9.6
+        environment:
+          - POSTGRES_USER=postgres
+          - POSTGRES_DB=statesman_test
+    steps: *steps
   build-ruby233-rails-429-mongo:
     docker:
       - image: circleci/ruby:2.3.3-node
@@ -368,6 +440,12 @@ workflows:
       - build-ruby241-rails-513-mongo
       - build-ruby241-rails-513-mysql
       - build-ruby241-rails-513-postgres
+      - build-ruby241-rails-523-mongo
+      - build-ruby241-rails-523-mysql
+      - build-ruby241-rails-523-postgres
+      - build-ruby262-rails-600-mongo
+      - build-ruby262-rails-600-mysql
+      - build-ruby262-rails-600-postgres
       - build-ruby233-rails-429-mongo
       - build-ruby233-rails-429-mysql
       - build-ruby233-rails-429-postgres

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -94,14 +94,12 @@ class CreateMyActiveRecordModelTransitionMigration < MIGRATION_CLASS
                 %i[my_active_record_model_id most_recent],
                 unique: true,
                 where: "most_recent",
-                name: "index_my_active_record_model_transitions_"\
-                      "parent_most_recent"
+                name: "index_my_active_record_model_transitions_parent_latest"
     else
       add_index :my_active_record_model_transitions,
                 %i[my_active_record_model_id most_recent],
                 unique: true,
-                name: "index_my_active_record_model_transitions_"\
-                      "parent_most_recent"
+                name: "index_my_active_record_model_transitions_parent_latest"
     end
   end
 end
@@ -173,13 +171,13 @@ class CreateOtherActiveRecordModelTransitionMigration < MIGRATION_CLASS
                 unique: true,
                 where: "most_recent",
                 name: "index_other_active_record_model_transitions_"\
-                      "parent_most_recent"
+                      "parent_latest"
     else
       add_index :other_active_record_model_transitions,
                 %i[other_active_record_model_id most_recent],
                 unique: true,
                 name: "index_other_active_record_model_transitions_"\
-                      "parent_most_recent"
+                      "parent_latest"
     end
   end
 end
@@ -188,8 +186,7 @@ end
 class DropMostRecentColumn < MIGRATION_CLASS
   def change
     remove_index :my_active_record_model_transitions,
-                 name: "index_my_active_record_model_transitions_"\
-                       "parent_most_recent"
+                 name: "index_my_active_record_model_transitions_parent_latest"
     remove_column :my_active_record_model_transitions, :most_recent
   end
 end
@@ -270,14 +267,12 @@ class CreateNamespacedARModelTransitionMigration < MIGRATION_CLASS
                 %i[my_active_record_model_id most_recent],
                 unique: true,
                 where: "most_recent",
-                name: "index_namespace_model_transitions_"\
-                      "parent_most_recent"
+                name: "index_namespace_model_transitions_parent_latest"
     else
       add_index :my_namespace_my_active_record_model_transitions,
                 %i[my_active_record_model_id most_recent],
                 unique: true,
-                name: "index_namespace_model_transitions_"\
-                      "parent_most_recent"
+                name: "index_namespace_model_transitions_parent_latest"
     end
   end
   # rubocop:enable MethodLength

--- a/statesman.gemspec
+++ b/statesman.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "ammeter", "~> 1.1"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "gc_ruboconfig", "~> 2.3.9"
-  spec.add_development_dependency "mysql2", "~> 0.4.0"
+  spec.add_development_dependency "mysql2", ">= 0.4", "< 0.6"
   spec.add_development_dependency "pg", "~> 0.18"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rails", ">= 3.2"


### PR DESCRIPTION
Previously ~~the MySQL tests~~ all the transition conflict error tests were passing on Rails 6 because the index name included the bits we expecting.

In the wild, people don't always have nice names for their indexes, so relying on them including the names of the columns we're interested in isn't robust. This PR looks up the indexes properly.