### PR TITLE
Use OUTER JOIN only when necessary.

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -75,7 +75,8 @@ module Statesman
         end
 
         def most_recent_transition_alias
-          "most_recent_#{transition_name.to_s.singularize}"
+          @most_recent_transition_alias ||=
+            "most_recent_#{transition_name.to_s.singularize}"
         end
 
         def db_true

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -8,24 +8,30 @@ module Statesman
       module ClassMethods
         def in_state(*states)
           states = states.flatten.map(&:to_s)
+          includes_initial = initial_state.to_s.in?(states)
 
-          joins(most_recent_transition_join).
-            where(states_where(most_recent_transition_alias, states), states)
+          joins(most_recent_transition_join(includes_initial)).
+            where(states_where(includes_initial), states)
         end
 
         def not_in_state(*states)
           states = states.flatten.map(&:to_s)
+          includes_initial = initial_state.to_s.in?(states)
 
-          joins(most_recent_transition_join).
-            where("NOT (#{states_where(most_recent_transition_alias, states)})",
-                  states)
+          joins(most_recent_transition_join(includes_initial)).
+            where("NOT (#{states_where(includes_initial)})", states)
         end
 
-        def most_recent_transition_join
-          "LEFT OUTER JOIN #{model_table} AS #{most_recent_transition_alias}
-             ON #{table_name}.id =
-                  #{most_recent_transition_alias}.#{model_foreign_key}
+        def most_recent_transition_join(includes_initial = true)
+          if includes_initial
+            "LEFT OUTER JOIN #{model_table} AS #{most_recent_transition_alias}
+             ON #{table_name}.id = #{most_recent_transition_alias}.#{model_foreign_key}
              AND #{most_recent_transition_alias}.most_recent = #{db_true}"
+          else
+            "JOIN #{model_table} AS #{most_recent_transition_alias}
+             ON #{table_name}.id = #{most_recent_transition_alias}.#{model_foreign_key}
+             AND #{most_recent_transition_alias}.most_recent = #{db_true}"
+          end
         end
 
         private
@@ -48,11 +54,11 @@ module Statesman
           @transition_reflection ||= reflect_on_all_associations(:has_many).
             find { |value| value.klass == transition_class }.
             tap do |value|
-              if value.nil?
-                raise MissingTransitionAssociation,
-                  "Could not find has_many association between #{self.class} " \
-                  "and #{transition_class}."
-              end
+            if value.nil?
+              raise MissingTransitionAssociation,
+                    "Could not find has_many association between #{self.class} " \
+                    "and #{transition_class}."
+            end
           end
         end
 
@@ -64,13 +70,12 @@ module Statesman
           transition_reflection.table_name
         end
 
-        def states_where(temporary_table_name, states)
-          if initial_state.to_s.in?(states.map(&:to_s))
-            "#{temporary_table_name}.to_state IN (?) OR " \
-            "#{temporary_table_name}.to_state IS NULL"
+        def states_where(includes_initial)
+          if includes_initial
+            "#{most_recent_transition_alias}.to_state IN (?) OR " \
+            "#{most_recent_transition_alias}.to_state IS NULL"
           else
-            "#{temporary_table_name}.to_state IN (?) AND " \
-            "#{temporary_table_name}.to_state IS NOT NULL"
+            "#{most_recent_transition_alias}.to_state IN (?)"
           end
         end
 
@@ -80,7 +85,7 @@ module Statesman
         end
 
         def db_true
-          ::ActiveRecord::Base.connection.quote(true)
+          ::ActiveRecord::Base.connection.quoted_true
         end
       end
     end

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -45,13 +45,15 @@ module Statesman
         end
 
         def transition_reflection
-          reflect_on_all_associations(:has_many).each do |value|
-            return value if value.klass == transition_class
+          @transition_reflection ||= reflect_on_all_associations(:has_many).
+            find { |value| value.klass == transition_class }.
+            tap do |value|
+              if value.nil?
+                raise MissingTransitionAssociation,
+                  "Could not find has_many association between #{self.class} " \
+                  "and #{transition_class}."
+              end
           end
-
-          raise MissingTransitionAssociation,
-                "Could not find has_many association between #{self.class} " \
-                "and #{transition_class}."
         end
 
         def model_foreign_key

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -140,6 +140,7 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
           OtherActiveRecordModelTransition
         end
       end
+      MyActiveRecordModel.send(:include, Statesman::Adapters::ActiveRecordQueries)
     end
 
     describe ".in_state" do


### PR DESCRIPTION
The current behaviour of `LEFT OUTER` and `IS NOT NULL` when
querying states emulates a `JOIN`.
However databases can choose to optimize them differently.