### PR TITLE
No easy way to find previous state

### DIFF
--- a/lib/generators/statesman/templates/active_record_transition_model.rb.erb
+++ b/lib/generators/statesman/templates/active_record_transition_model.rb.erb
@@ -9,7 +9,7 @@ class <%= klass %> < <%= Statesman::Utils.rails_5_or_higher? ? 'ApplicationRecor
   # self.updated_timestamp_column = nil
 
 <%- unless Statesman::Utils.rails_4_or_higher? -%>
-  attr_accessible :to_state, :metadata, :sort_key
+  attr_accessible :from_state, :to_state, :metadata, :sort_key
 
 <%- end -%>
   belongs_to :<%= parent_name %><%= class_name_option %>, inverse_of: :<%= table_name %>

--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -1,6 +1,7 @@
 class Create<%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveRecord::Migration.current_version}]" if Statesman::Utils.rails_5_or_higher? %>
   def change
     create_table :<%= table_name %> do |t|
+      t.string :from_state, null: false
       t.string :to_state, null: false
       t.text :metadata<%= ", default: #{metadata_default_value}" unless mysql? %>
       t.integer :sort_key, null: false

--- a/lib/generators/statesman/templates/mongoid_transition_model.rb.erb
+++ b/lib/generators/statesman/templates/mongoid_transition_model.rb.erb
@@ -2,6 +2,7 @@ class <%= klass %>
   include Mongoid::Document
   include Mongoid::Timestamps
 
+  field :from_state, type: String
   field :to_state, type: String
   field :sort_key, type: Integer
   field :statesman_metadata, type: Hash

--- a/lib/generators/statesman/templates/update_migration.rb.erb
+++ b/lib/generators/statesman/templates/update_migration.rb.erb
@@ -1,5 +1,6 @@
 class AddStatesmanTo<%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveRecord::Migration.current_version}]" if Statesman::Utils.rails_5_or_higher? %>
   def change
+    add_column :<%= table_name %>, :from_state, :string, null: false
     add_column :<%= table_name %>, :to_state, :string, null: false
     add_column :<%= table_name %>, :metadata, :text<%= ", default: #{metadata_default_value}" unless mysql? %>
     add_column :<%= table_name %>, :sort_key, :integer, null: false

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -64,12 +64,7 @@ module Statesman
       private
 
       def create_transition(from, to, metadata)
-        transition_attributes = { to_state: to,
-                                  sort_key: next_sort_key,
-                                  metadata: metadata }
-
-        transition_attributes[:most_recent] = true
-
+        transition_attributes = transition_attributes(from, to, metadata)
         transition = transitions_for_parent.build(transition_attributes)
 
         ::ActiveRecord::Base.transaction(requires_new: true) do
@@ -90,6 +85,16 @@ module Statesman
             @observer.execute(:after_commit, from, to, transition)
           end,
         )
+      end
+
+      def transition_attributes(from, to, metadata)
+        {
+          from_state: from,
+          to_state: to,
+          sort_key: next_sort_key,
+          metadata: metadata,
+          most_recent: true,
+        }
       end
 
       def transitions_for_parent

--- a/lib/statesman/adapters/memory.rb
+++ b/lib/statesman/adapters/memory.rb
@@ -18,7 +18,7 @@ module Statesman
       def create(from, to, metadata = {})
         from = from.to_s
         to = to.to_s
-        transition = transition_class.new(to, next_sort_key, metadata)
+        transition = transition_class.new(from, to, next_sort_key, metadata)
 
         @observer.execute(:before, from, to, transition)
         @history << transition

--- a/lib/statesman/adapters/memory_transition.rb
+++ b/lib/statesman/adapters/memory_transition.rb
@@ -3,13 +3,15 @@ module Statesman
     class MemoryTransition
       attr_accessor :created_at
       attr_accessor :updated_at
+      attr_accessor :from_state
       attr_accessor :to_state
       attr_accessor :sort_key
       attr_accessor :metadata
 
-      def initialize(to, sort_key, metadata = {})
+      def initialize(from, to, sort_key, metadata = {})
         @created_at = Time.now
         @updated_at = Time.now
+        @from_state = from
         @to_state = to
         @sort_key = sort_key
         @metadata = metadata

--- a/lib/statesman/adapters/mongoid.rb
+++ b/lib/statesman/adapters/mongoid.rb
@@ -18,7 +18,8 @@ module Statesman
       def create(from, to, metadata = {})
         from = from.to_s
         to = to.to_s
-        transition = transitions_for_parent.build(to_state: to,
+        transition = transitions_for_parent.build(from_state: from,
+                                                  to_state: to,
                                                   sort_key: next_sort_key,
                                                   statesman_metadata: metadata)
 

--- a/spec/statesman/adapters/memory_transition_spec.rb
+++ b/spec/statesman/adapters/memory_transition_spec.rb
@@ -3,10 +3,12 @@ require "statesman/adapters/memory_transition"
 
 describe Statesman::Adapters::MemoryTransition do
   describe "#initialize" do
+    let(:from) { :n }
     let(:to) { :y }
     let(:sort_key) { 0 }
-    let(:create) { described_class.new(to, sort_key) }
+    let(:create) { described_class.new(from, to, sort_key) }
 
+    specify { expect(create.from_state).to equal(from) }
     specify { expect(create.to_state).to equal(to) }
     specify { expect(create.created_at).to be_a(Time) }
     specify { expect(create.updated_at).to be_a(Time) }
@@ -14,7 +16,7 @@ describe Statesman::Adapters::MemoryTransition do
 
     context "with metadata passed" do
       let(:metadata) { { some: :hash } }
-      let(:create) { described_class.new(to, sort_key, metadata) }
+      let(:create) { described_class.new(from, to, sort_key, metadata) }
 
       specify { expect(create.metadata).to eq(metadata) }
     end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -61,6 +61,7 @@ end
 class CreateMyActiveRecordModelTransitionMigration < MIGRATION_CLASS
   def change
     create_table :my_active_record_model_transitions do |t|
+      t.string  :from_state
       t.string  :to_state
       t.integer :my_active_record_model_id
       t.integer :sort_key
@@ -137,10 +138,11 @@ class CreateOtherActiveRecordModelMigration < MIGRATION_CLASS
   end
 end
 
-# rubocop:disable MethodLength
+# rubocop:disable MethodLength, Metrics/AbcSize
 class CreateOtherActiveRecordModelTransitionMigration < MIGRATION_CLASS
   def change
     create_table :other_active_record_model_transitions do |t|
+      t.string  :from_state
       t.string  :to_state
       t.integer :other_active_record_model_id
       t.integer :sort_key
@@ -181,7 +183,7 @@ class CreateOtherActiveRecordModelTransitionMigration < MIGRATION_CLASS
     end
   end
 end
-# rubocop:enable MethodLength
+# rubocop:enable MethodLength, Metrics/AbcSize
 
 class DropMostRecentColumn < MIGRATION_CLASS
   def change
@@ -235,10 +237,11 @@ class CreateNamespacedARModelMigration < MIGRATION_CLASS
   end
 end
 
-# rubocop:disable MethodLength
+# rubocop:disable MethodLength, Metrics/AbcSize
 class CreateNamespacedARModelTransitionMigration < MIGRATION_CLASS
   def change
     create_table :my_namespace_my_active_record_model_transitions do |t|
+      t.string  :from_state
       t.string  :to_state
       t.integer :my_active_record_model_id
       t.integer :sort_key
@@ -275,5 +278,5 @@ class CreateNamespacedARModelTransitionMigration < MIGRATION_CLASS
                 name: "index_namespace_model_transitions_parent_latest"
     end
   end
-  # rubocop:enable MethodLength
+  # rubocop:enable MethodLength, Metrics/AbcSize
 end

--- a/spec/support/mongoid.rb
+++ b/spec/support/mongoid.rb
@@ -16,6 +16,7 @@ class MyMongoidModelTransition
   include Mongoid::Document
   include Mongoid::Timestamps
 
+  field :from_state, type: String
   field :to_state, type: String
   field :sort_key, type: Integer
   field :statesman_metadata, type: Hash


### PR DESCRIPTION
Closes #263 

Before:
```
previous_state = project.transitions.where(most_recent: false).last.to_state || project.initial_state
```

After:
```
project.last_transition.from_state
```