### PR TITLE
Correct access of metadata via state_machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ You could also use a calculated column or view in your database.
 Given a field `foo` that was stored in the metadata, you can access it like so:
 
 ```ruby
-model_instance.last_transition.metadata["foo"]
+model_instance.state_machine.last_transition.metadata["foo"]
 ```
 
 #### Events


### PR DESCRIPTION
```
model_instance.last_transition.metadata["foo"]
```
Requires that the `last_transition` method is delegated to the state_machine which doesn't happen in the examples in the README, so you have to fully qualify the lookup.