### PR TITLE
Inverse the order of writes on create transition

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -125,7 +125,7 @@ module Statesman
       def update_most_recents(most_recent_id)
         transitions = transitions_for_parent
         last_or_current = transitions.where(id: most_recent_id).or(
-          transitions.where(most_recent: true)
+          transitions.where(most_recent: true),
         )
 
         last_or_current.update_all(
@@ -246,7 +246,7 @@ module Statesman
         return nil if column.nil?
 
         [
-          column, ::ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.now,
+          column, ::ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.now
         ]
       end
     end


### PR DESCRIPTION
### Context

Dependabot is using statesman, and we are running the Dependabot service using MySQL at GitHub.
After some load testing the system, we found out some increasing number of deadlocks coming from states man. This fixed the problem for us.

This is a lock-free solution for #228. Probably also fixes #206

### Short problem description
When we were trying to call `ar_model.transition_to!`, we would get a Deadlock error if the system was under pressure. (lots of concurrent transitions happening at the same time) 

### Detailed problem and root cause analysis
#### Some context
When doing a `transition_to!` statesman will do, mainly, [two operations](https://github.com/gocardless/statesman/blob/fdab116b9b0d9e1d77b5df151641761fbc7c15dd/lib/statesman/adapters/active_record.rb#L75-L82) in the database, inside the same transaction: 
1. Update the old transitions to mark them as non-most-recent
2. Insert the new transition with a most_recent set to TRUE. 

Also, the transitions table usually have two unique indexes, `(parent_id,sort_key)` and  `(parent_id,most_recent)`, the second index is there to guarantee we only have one most_recent transition for the parent entry. Thus we need the update before the insert.

#### Problem
MySQL default transaction isolation level is `REPEATABLE READ` and that's what we use at Dependabot/GitHub. [It states](https://dev.mysql.com/doc/refman/5.7/en/innodb-transaction-isolation-levels.html#isolevel_repeatable-read):
> This is the default isolation level for InnoDB. Consistent reads within the same transaction read the snapshot established by the first read.

What means is if in a loop, we do the same SELECT within a db transaction, even if other clients have committed data between the runs, it will, ALWAYS, see the first results it saw the first time.
That is also respected when doing writes (Update/Delete). so `UPDATE transitions SET most_recent=NULL where parent_id=1 AND most_recent=true;` will put an exclusive lock on the row for that unique index, as it cannot allow other transactions to change the data. However, if there is no row to update, MySQL will have to create a next-key lock, to also prevent others from changing this data, as the transaction's view of the snapshot didn't include any rows, as the UPDATE returned 0 rows changed.
The issue is, two independent transactions can put the next-key lock on the table (even if they reference different columns values on the index), and when it tries to do the next operation, the insert, it will lock, waiting for the next-key lock to be released. Therefore, if two updates happen first, and two inserts after, they will deadlock. (for better understanding see Simulation 1)
However, if the Update would have changed at least one row, there would be no locking, as for REPEATABLE READ that would be our current snapshot of the data. Thus no need for a gap locking. 
[See](https://dev.mysql.com/doc/refman/5.7/en/innodb-locking.html#innodb-gap-locks)
> If id is not indexed or has a nonunique index, the statement does lock the preceding gap.

This is also explained on this [2003 issue](https://bugs.mysql.com/bug.php?id=1866), by the people that wrote InnoDB, and on a few articles: [1](https://www.percona.com/blog/2013/12/12/one-more-innodb-gap-lock-to-avoid/) [2](https://www.percona.com/blog/2012/03/27/innodbs-gap-locks/)


### Solution

There are a few different ways to fix this. The easiest is just to (1)retry on deadlock, another one,(2) would be to change the transaction isolation level for that transaction to READ COMMITTED, which means SELECTS within the transaction are not consistent, and will always return committed data, thus, MySQL will not create the gap lock, as it is safe to update without the lock.
The problem of 1 is that we would still need to limit the number of retries, and eventually can still have the deadlocks, and number 2 would require us to always use ROW based replication as statement base replication wants REPEATABLE READ. [Also, not advised to change the transaction isolation level inside a library]
Instead, we can tackle the root problem: First, I thought in doing a select, and if transition data had to be updated do the update. However, that is race prone.
The actual fix is, re-order the operations, and always do the insert before, so we know the next Update will at least touch one row, and make our latest transition most_recent after. Thus, no next-key lock will happen and less contention will be created. 

To simulate this: 
### Simulation 1 (SQL)
A and B are different MySQL clients:
```
CREATE TABLE `transitions` (
  `id` bigint(20) NOT NULL AUTO_INCREMENT,
  `to_state` varchar(40) NOT NULL,
  `sort_key` int(11) NOT NULL,
  `parent_id` bigint(20) NOT NULL,
  `most_recent` tinyint(1) DEFAULT NULL,
  PRIMARY KEY (`id`),
  UNIQUE KEY `index_parent_sort` (`parent_id`,`sort_key`),
  UNIQUE KEY `index_parent_most_recent` (`parent_id`,`most_recent`)
) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4

A: START TRANSACTION;
B: START TRANSACTION;
A: UPDATE transitions SET most_recent=NULL where parent_id=1 AND most_recent=true;
B: UPDATE transitions SET most_recent=NULL where parent_id=42 AND most_recent=true;
A: INSERT INTO transitions(to_state, sort_key, parent_id, most_recent) values ('pending', 10, 1, TRUE);
B: INSERT INTO transitions(to_state, sort_key, parent_id, most_recent) values ('pending', 10, 42, TRUE);
```


cc @greysteil @hmarr 