### PR TITLE
Fix statesman index detection

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -140,8 +140,8 @@ module Statesman
           select do |index|
             next unless index.unique
 
-            index.columns.sort == [parent_join_foreign_key, "sort_key"] ||
-              index.columns.sort == [parent_join_foreign_key, "most_recent"]
+            index.columns.sort == [parent_join_foreign_key, "sort_key"].sort ||
+              index.columns.sort == [parent_join_foreign_key, "most_recent"].sort
           end
       end
 

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -140,6 +140,8 @@ module Statesman
           select do |index|
             next unless index.unique
 
+            # We care about the columns used in the index, but not necessarily
+            # the order, which is why we sort both sides of the comparison here
             index.columns.sort == [parent_join_foreign_key, "sort_key"].sort ||
               index.columns.sort == [parent_join_foreign_key, "most_recent"].sort
           end


### PR DESCRIPTION
The previous logic worked fine with parent tables that (approximately) began with the letters A-S, but with tables that (approximately) started with the letters T-Z, the comparison would fail, which ultimately resulted in the `RecordNotUnique` exception not being converted to a `TransitionConflictError`. Among other things, this prevents `retry_conflicts` from working.