### PR TITLE
Remove mongo test runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 
 references:
@@ -30,14 +31,6 @@ references:
       path: /tmp/test-results
 
 jobs:
-  build-ruby241-rails-429-mongo:
-    docker:
-      - image: circleci/ruby:2.4.1-node
-        environment:
-          - RAILS_VERSION=4.2.9
-          - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3
-    steps: *steps
   build-ruby241-rails-429-mysql:
     docker:
       - image: circleci/ruby:2.4.1-node
@@ -65,14 +58,6 @@ jobs:
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
-    steps: *steps
-  build-ruby241-rails-505-mongo:
-    docker:
-      - image: circleci/ruby:2.4.1-node
-        environment:
-          - RAILS_VERSION=5.0.5
-          - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3
     steps: *steps
   build-ruby241-rails-505-mysql:
     docker:
@@ -102,14 +87,6 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
     steps: *steps
-  build-ruby241-rails-513-mongo:
-    docker:
-      - image: circleci/ruby:2.4.1-node
-        environment:
-          - RAILS_VERSION=5.1.3
-          - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3
-    steps: *steps
   build-ruby241-rails-513-mysql:
     docker:
       - image: circleci/ruby:2.4.1-node
@@ -137,14 +114,6 @@ jobs:
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
-    steps: *steps
-  build-ruby262-rails-600-mongo:
-    docker:
-      - image: circleci/ruby:2.6.2-node
-        environment:
-          - RAILS_VERSION=6.0.0.rc1
-          - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3
     steps: *steps
   build-ruby262-rails-600-mysql:
     docker:
@@ -174,14 +143,6 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
     steps: *steps
-  build-ruby262-rails-master-mongo:
-    docker:
-      - image: circleci/ruby:2.6.2-node
-        environment:
-          - RAILS_VERSION=master
-          - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3
-    steps: *steps
   build-ruby262-rails-master-mysql:
     docker:
       - image: circleci/ruby:2.6.2-node
@@ -209,14 +170,6 @@ jobs:
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
-    steps: *steps
-  build-ruby241-rails-523-mongo:
-    docker:
-      - image: circleci/ruby:2.4.1-node
-        environment:
-          - RAILS_VERSION=5.2.3
-          - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3
     steps: *steps
   build-ruby241-rails-523-mysql:
     docker:
@@ -246,14 +199,6 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
     steps: *steps
-  build-ruby233-rails-429-mongo:
-    docker:
-      - image: circleci/ruby:2.3.3-node
-        environment:
-          - RAILS_VERSION=4.2.9
-          - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3
-    steps: *steps
   build-ruby233-rails-429-mysql:
     docker:
       - image: circleci/ruby:2.3.3-node
@@ -281,14 +226,6 @@ jobs:
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
-    steps: *steps
-  build-ruby233-rails-505-mongo:
-    docker:
-      - image: circleci/ruby:2.3.3-node
-        environment:
-          - RAILS_VERSION=5.0.5
-          - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3
     steps: *steps
   build-ruby233-rails-505-mysql:
     docker:
@@ -318,14 +255,6 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
     steps: *steps
-  build-ruby233-rails-513-mongo:
-    docker:
-      - image: circleci/ruby:2.3.3-node
-        environment:
-          - RAILS_VERSION=5.1.3
-          - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3
-    steps: *steps
   build-ruby233-rails-513-mysql:
     docker:
       - image: circleci/ruby:2.3.3-node
@@ -353,14 +282,6 @@ jobs:
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
-    steps: *steps
-  build-ruby227-rails-429-mongo:
-    docker:
-      - image: circleci/ruby:2.2.7-node
-        environment:
-          - RAILS_VERSION=4.2.9
-          - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3
     steps: *steps
   build-ruby227-rails-429-mysql:
     docker:
@@ -390,14 +311,6 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
     steps: *steps
-  build-ruby227-rails-505-mongo:
-    docker:
-      - image: circleci/ruby:2.2.7-node
-        environment:
-          - RAILS_VERSION=5.0.5
-          - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3
-    steps: *steps
   build-ruby227-rails-505-mysql:
     docker:
       - image: circleci/ruby:2.2.7-node
@@ -425,14 +338,6 @@ jobs:
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
-    steps: *steps
-  build-ruby227-rails-513-mongo:
-    docker:
-      - image: circleci/ruby:2.2.7-node
-        environment:
-          - RAILS_VERSION=5.1.3
-          - DATABASE_DEPENDENCY_PORT=27017
-      - image: circleci/mongo:3
     steps: *steps
   build-ruby227-rails-513-mysql:
     docker:
@@ -467,39 +372,27 @@ workflows:
   version: 2
   tests:
     jobs:
-      - build-ruby241-rails-429-mongo
       - build-ruby241-rails-429-mysql
       - build-ruby241-rails-429-postgres
-      - build-ruby241-rails-505-mongo
       - build-ruby241-rails-505-mysql
       - build-ruby241-rails-505-postgres
-      - build-ruby241-rails-513-mongo
       - build-ruby241-rails-513-mysql
       - build-ruby241-rails-513-postgres
-      - build-ruby241-rails-523-mongo
       - build-ruby241-rails-523-mysql
       - build-ruby241-rails-523-postgres
-      - build-ruby262-rails-600-mongo
       - build-ruby262-rails-600-mysql
       - build-ruby262-rails-600-postgres
-      - build-ruby262-rails-master-mongo
       - build-ruby262-rails-master-mysql
       - build-ruby262-rails-master-postgres
-      - build-ruby233-rails-429-mongo
       - build-ruby233-rails-429-mysql
       - build-ruby233-rails-429-postgres
-      - build-ruby233-rails-505-mongo
       - build-ruby233-rails-505-mysql
       - build-ruby233-rails-505-postgres
-      - build-ruby233-rails-513-mongo
       - build-ruby233-rails-513-mysql
       - build-ruby233-rails-513-postgres
-      - build-ruby227-rails-429-mongo
       - build-ruby227-rails-429-mysql
       - build-ruby227-rails-429-postgres
-      - build-ruby227-rails-505-mongo
       - build-ruby227-rails-505-mysql
       - build-ruby227-rails-505-postgres
-      - build-ruby227-rails-513-mongo
       - build-ruby227-rails-513-mysql
       - build-ruby227-rails-513-postgres


### PR DESCRIPTION
In anticipation of #266, this commit removes all mongo related test runs
from CI. This will reduce noise from failing mongo tests that we have no
intention of supporting into the next release.