### PR TITLE
Cleaner ActiveRecordQueries mixin

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,12 @@ Then, link it to your model:
 
 ```ruby
 class Order < ActiveRecord::Base
+  has_many :order_transitions, autosave: false
+
   include Statesman::Adapters::ActiveRecordQueries[
     transition_class: OrderTransition,
     initial_state: :pending
   ]
-
-  has_many :order_transitions, autosave: false
 
   def state_machine
     @state_machine ||= OrderStateMachine.new(self, transition_class: OrderTransition)
@@ -331,6 +331,7 @@ in 5.0.0.
 
 ```ruby
 class Order < ActiveRecord::Base
+  has_many :order_transitions, autosave: false
   include Statesman::Adapters::ActiveRecordQueries[
     transition_class: OrderTransition,
     initial_state: OrderStateMachine.initial_state

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -2,50 +2,101 @@ module Statesman
   module Adapters
     module ActiveRecordQueries
       def self.included(base)
-        base.extend(ClassMethods)
-      end
-
-      module ClassMethods
-        def in_state(*states)
-          states = states.flatten.map(&:to_s)
-
-          joins(most_recent_transition_join).
-            where(states_where(most_recent_transition_alias, states), states)
+        %i[transition_class initial_state].each do |method|
+          unless base.respond_to?(:method)
+            raise NotImplementedError,
+                  "A #{method} method should be defined on the model. " \
+                  "Alternatively, use the new form of `extend " \
+                  "Statesman::Adapters::ActiveRecordQueries.new(" \
+                  "transition_class: MyTransition, " \
+                  "initial_state: :some_state)`"
+          end
         end
 
-        def not_in_state(*states)
-          states = states.flatten.map(&:to_s)
+        base.include(ClassMethods.new(
+          transition_class: base.transition_class,
+          initial_state: base.initial_state,
+          most_recent_transition_alias: base.try(:most_recent_transition_alias),
+          transition_name: base.try(:transition_name)
+        ))
+      end
 
-          joins(most_recent_transition_join).
-            where("NOT (#{states_where(most_recent_transition_alias, states)})",
-                  states)
+      def self.[](**args)
+        ClassMethods.new(**args)
+      end
+
+      class ClassMethods < Module
+        def initialize(**args)
+          @args = args
+        end
+
+        def included(base)
+          query_builder = QueryBuilder.new(base, **@args)
+          klass = self
+          existing_inherited = base.method(:inherited)
+          base.define_singleton_method(:inherited) do |subclass|
+            existing_inherited.call(subclass)
+            subclass.send(:include, klass)
+          end
+
+          base.define_singleton_method(:most_recent_transition_join) do
+            query_builder.most_recent_transition_join
+          end
+
+          base.define_singleton_method(:in_state) do |*states|
+            states = states.flatten.map(&:to_s)
+
+            joins(most_recent_transition_join)
+              .where(query_builder.states_where(states), states)
+          end
+
+          base.define_singleton_method(:not_in_state) do |*states|
+            states = states.flatten.map(&:to_s)
+
+            joins(most_recent_transition_join)
+              .where("NOT (#{query_builder.states_where(states)})", states)
+          end
+        end
+      end
+
+      class QueryBuilder
+        def initialize(model, transition_class:, initial_state:,
+                       most_recent_transition_alias: nil,
+                      transition_name: nil)
+          @model = model
+          @transition_class = transition_class
+          @initial_state = initial_state
+          @most_recent_transition_alias = most_recent_transition_alias
+          @transition_name = transition_name
+        end
+
+        def states_where(states)
+          if initial_state.to_s.in?(states.map(&:to_s))
+            "#{most_recent_transition_alias}.to_state IN (?) OR " \
+            "#{most_recent_transition_alias}.to_state IS NULL"
+          else
+            "#{most_recent_transition_alias}.to_state IN (?) AND " \
+            "#{most_recent_transition_alias}.to_state IS NOT NULL"
+          end
         end
 
         def most_recent_transition_join
           "LEFT OUTER JOIN #{model_table} AS #{most_recent_transition_alias}
-             ON #{table_name}.id =
+             ON #{model.table_name}.id =
                   #{most_recent_transition_alias}.#{model_foreign_key}
              AND #{most_recent_transition_alias}.most_recent = #{db_true}"
         end
 
         private
 
-        def transition_class
-          raise NotImplementedError, "A transition_class method should be " \
-                                     "defined on the model"
-        end
-
-        def initial_state
-          raise NotImplementedError, "An initial_state method should be " \
-                                     "defined on the model"
-        end
+        attr_reader :model, :transition_class, :initial_state
 
         def transition_name
-          transition_class.table_name.to_sym
+          @transition_name || transition_class.table_name.to_sym
         end
 
         def transition_reflection
-          reflect_on_all_associations(:has_many).each do |value|
+          model.reflect_on_all_associations(:has_many).each do |value|
             return value if value.klass == transition_class
           end
 
@@ -62,18 +113,9 @@ module Statesman
           transition_reflection.table_name
         end
 
-        def states_where(temporary_table_name, states)
-          if initial_state.to_s.in?(states.map(&:to_s))
-            "#{temporary_table_name}.to_state IN (?) OR " \
-            "#{temporary_table_name}.to_state IS NULL"
-          else
-            "#{temporary_table_name}.to_state IN (?) AND " \
-            "#{temporary_table_name}.to_state IS NOT NULL"
-          end
-        end
-
         def most_recent_transition_alias
-          "most_recent_#{transition_name.to_s.singularize}"
+          @most_recent_transition_alias ||
+            "most_recent_#{transition_name.to_s.singularize}"
         end
 
         def db_true

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -1,6 +1,19 @@
 require "spec_helper"
 
 describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
+  let(:config_type) { :new }
+
+  def configure_old(klass, transition_class)
+    klass.define_singleton_method(:transition_class) { transition_class }
+    klass.define_singleton_method(:initial_state) { :initial }
+    klass.send(:include, described_class)
+  end
+
+  def configure_new(klass, transition_class)
+    klass.send(:include, described_class[transition_class: transition_class,
+                                         initial_state: :initial])
+  end
+
   before do
     prepare_model_table
     prepare_transitions_table
@@ -9,27 +22,14 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
 
     Statesman.configure { storage_adapter(Statesman::Adapters::ActiveRecord) }
 
-    MyActiveRecordModel.send(:include, Statesman::Adapters::ActiveRecordQueries)
-    MyActiveRecordModel.class_eval do
-      def self.transition_class
-        MyActiveRecordModelTransition
-      end
-
-      def self.initial_state
-        :initial
-      end
-    end
-
-    OtherActiveRecordModel.send(:include,
-                                Statesman::Adapters::ActiveRecordQueries)
-    OtherActiveRecordModel.class_eval do
-      def self.transition_class
-        OtherActiveRecordModelTransition
-      end
-
-      def self.initial_state
-        :initial
-      end
+    if config_type == :old
+      configure_old(MyActiveRecordModel, MyActiveRecordModelTransition)
+      configure_old(OtherActiveRecordModel, OtherActiveRecordModelTransition)
+    elsif config_type == :new
+      configure_new(MyActiveRecordModel, MyActiveRecordModelTransition)
+      configure_new(OtherActiveRecordModel, OtherActiveRecordModelTransition)
+    else
+      raise "Unknown config type #{config_type}"
     end
 
     MyActiveRecordModel.send(:has_one, :other_active_record_model)
@@ -59,105 +59,147 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
     model
   end
 
-  describe ".in_state" do
-    context "given a single state" do
-      subject { MyActiveRecordModel.in_state(:succeeded) }
+  shared_examples "testing methods" do
+    describe ".in_state" do
+      context "given a single state" do
+        subject { MyActiveRecordModel.in_state(:succeeded) }
 
-      it { is_expected.to include model }
-      it { is_expected.to_not include other_model }
-    end
-
-    context "given multiple states" do
-      subject { MyActiveRecordModel.in_state(:succeeded, :failed) }
-
-      it { is_expected.to include model }
-      it { is_expected.to include other_model }
-    end
-
-    context "given the initial state" do
-      subject { MyActiveRecordModel.in_state(:initial) }
-
-      it { is_expected.to include initial_state_model }
-      it { is_expected.to include returned_to_initial_model }
-    end
-
-    context "given an array of states" do
-      subject { MyActiveRecordModel.in_state(%i[succeeded failed]) }
-
-      it { is_expected.to include model }
-      it { is_expected.to include other_model }
-    end
-
-    context "merging two queries" do
-      subject do
-        MyActiveRecordModel.in_state(:succeeded).
-          joins(:other_active_record_model).
-          merge(OtherActiveRecordModel.in_state(:initial))
+        it { is_expected.to include model }
+        it { is_expected.to_not include other_model }
       end
 
-      it { is_expected.to be_empty }
-    end
-  end
+      context "given multiple states" do
+        subject { MyActiveRecordModel.in_state(:succeeded, :failed) }
 
-  describe ".not_in_state" do
-    context "given a single state" do
-      subject { MyActiveRecordModel.not_in_state(:failed) }
+        it { is_expected.to include model }
+        it { is_expected.to include other_model }
+      end
 
-      it { is_expected.to include model }
-      it { is_expected.to_not include other_model }
-    end
+      context "given the initial state" do
+        subject { MyActiveRecordModel.in_state(:initial) }
 
-    context "given multiple states" do
-      subject(:not_in_state) { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
+        it { is_expected.to include initial_state_model }
+        it { is_expected.to include returned_to_initial_model }
+      end
 
-      it do
-        expect(not_in_state).to match_array([initial_state_model,
-                                             returned_to_initial_model])
+      context "given an array of states" do
+        subject { MyActiveRecordModel.in_state(%i[succeeded failed]) }
+
+        it { is_expected.to include model }
+        it { is_expected.to include other_model }
+      end
+
+      context "merging two queries" do
+        subject do
+          MyActiveRecordModel.in_state(:succeeded).
+            joins(:other_active_record_model).
+            merge(OtherActiveRecordModel.in_state(:initial))
+        end
+
+        it { is_expected.to be_empty }
       end
     end
 
-    context "given an array of states" do
-      subject(:not_in_state) { MyActiveRecordModel.not_in_state(%i[succeeded failed]) }
+    describe ".not_in_state" do
+      context "given a single state" do
+        subject { MyActiveRecordModel.not_in_state(:failed) }
 
-      it do
-        expect(not_in_state).to match_array([initial_state_model,
-                                             returned_to_initial_model])
+        it { is_expected.to include model }
+        it { is_expected.to_not include other_model }
       end
-    end
-  end
 
-  context "with a custom name for the transition association" do
-    before do
-      # Switch to using OtherActiveRecordModelTransition, so the existing
-      # relation with MyActiveRecordModelTransition doesn't interfere with
-      # this spec.
-      MyActiveRecordModel.send(:has_many,
-                               :custom_name,
-                               class_name: "OtherActiveRecordModelTransition")
+      context "given multiple states" do
+        subject(:not_in_state) { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
 
-      MyActiveRecordModel.class_eval do
-        def self.transition_class
-          OtherActiveRecordModelTransition
+        it do
+          expect(not_in_state).to match_array([initial_state_model,
+                                               returned_to_initial_model])
+        end
+      end
+
+      context "given an array of states" do
+        subject(:not_in_state) { MyActiveRecordModel.not_in_state(%i[succeeded failed]) }
+
+        it do
+          expect(not_in_state).to match_array([initial_state_model,
+                                               returned_to_initial_model])
         end
       end
     end
 
-    describe ".in_state" do
-      subject(:query) { MyActiveRecordModel.in_state(:succeeded) }
+    context "with a custom name for the transition association" do
+      before do
+        # Switch to using OtherActiveRecordModelTransition, so the existing
+        # relation with MyActiveRecordModelTransition doesn't interfere with
+        # this spec.
+        MyActiveRecordModel.send(:has_many,
+                                 :custom_name,
+                                 class_name: "OtherActiveRecordModelTransition")
 
-      specify { expect { query }.to_not raise_error }
+        MyActiveRecordModel.class_eval do
+          def self.transition_class
+            OtherActiveRecordModelTransition
+          end
+        end
+      end
+
+      describe ".in_state" do
+        subject(:query) { MyActiveRecordModel.in_state(:succeeded) }
+
+        specify { expect { query }.to_not raise_error }
+      end
     end
+
+    context "after_commit transactional integrity" do
+      before do
+        MyStateMachine.class_eval do
+          cattr_accessor(:after_commit_callback_executed) { false }
+
+          after_transition(from: :initial, to: :succeeded, after_commit: true) do
+            # This leaks state in a testable way if transactional integrity is broken.
+            MyStateMachine.after_commit_callback_executed = true
+          end
+        end
+      end
+
+      after do
+        MyStateMachine.class_eval do
+          callbacks[:after_commit] = []
+        end
+      end
+
+      let!(:model) do
+        MyActiveRecordModel.create
+      end
+
+      # rubocop:disable RSpec/ExampleLength
+      it do
+        expect do
+          ActiveRecord::Base.transaction do
+            model.state_machine.transition_to!(:succeeded)
+            raise ActiveRecord::Rollback
+          end
+        end.to_not change(MyStateMachine, :after_commit_callback_executed)
+      end
+      # rubocop:enable RSpec/ExampleLength
+    end
+  end
+
+  context "using old configuration method" do
+    let(:config_type) { :old }
+    include_examples "testing methods"
+  end
+
+  context "using new configuration method" do
+    let(:config_type) { :new }
+    include_examples "testing methods"
   end
 
   context "with no association with the transition class" do
     before do
       class UnknownModelTransition < OtherActiveRecordModelTransition; end
 
-      MyActiveRecordModel.class_eval do
-        def self.transition_class
-          UnknownModelTransition
-        end
-      end
+      configure_old(MyActiveRecordModel, UnknownModelTransition)
     end
 
     describe ".in_state" do
@@ -167,39 +209,5 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
         expect { query }.to raise_error(Statesman::MissingTransitionAssociation)
       end
     end
-  end
-
-  context "after_commit transactional integrity" do
-    before do
-      MyStateMachine.class_eval do
-        cattr_accessor(:after_commit_callback_executed) { false }
-
-        after_transition(from: :initial, to: :succeeded, after_commit: true) do
-          # This leaks state in a testable way if transactional integrity is broken.
-          MyStateMachine.after_commit_callback_executed = true
-        end
-      end
-    end
-
-    after do
-      MyStateMachine.class_eval do
-        callbacks[:after_commit] = []
-      end
-    end
-
-    let!(:model) do
-      MyActiveRecordModel.create
-    end
-
-    # rubocop:disable RSpec/ExampleLength
-    it do
-      expect do
-        ActiveRecord::Base.transaction do
-          model.state_machine.transition_to!(:succeeded)
-          raise ActiveRecord::Rollback
-        end
-      end.to_not change(MyStateMachine, :after_commit_callback_executed)
-    end
-    # rubocop:enable RSpec/ExampleLength
   end
 end


### PR DESCRIPTION
Pass configuration to the mixin as arguments, and only define the three
documented public methods, moving the other private methods into a
separate, inaccessible object.

The advantage of this is:
- we can check the presence of the right associations when the module is included (i.e. app boot), rather than at first load
- only the documented methods get defined, the others (although private), are still defined as private methods on the model in the old approach

Disadvantages are:
- the code is in some sense less clear (I'd say marginally but...subjective)
- the include must be executed _after_ the `has_many` - which is kinda icky style-wise (and potentially a *breaking change*)? Could argue that instead we should have an interface like
```ruby
Statesman::Adapter::ActiveRecordQueries.define(self, **options)
```
 (although that adds another indirection which hides the `include` more)


In the README I've defined this as a minor-level change because the old-style will still work. I think this is probably wrong now I'm writing about it, given that the check for the definition of the `transition_class` and `initial_state` class methods now runs when it's included, so if you had

```ruby
class Order < ApplicationRecord
  include Statesman::Adapter::ActiveRecordQueries
  has_many :order_transitions
  def self.transition_class
    OrderTransition
  end

  def self.initial_state
    :initial
  end
end
```
it'll break.

Can either:
- change the code to not check for those two methods until `in_state` runs
- make this totally non-backwards compatible and add it in v5.

Interested to hear thoughts from @lawrencejones and whoever else is maintaining this these days 😄 