### PR TITLE
Add common delegations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ class Order < ActiveRecord::Base
   end
 
   # Optionally delegate some methods
-  delegate :can_transition_to?, :transition_to!, :transition_to, :current_state,
-           to: :state_machine
+
+  delegate :can_transition_to?, :current_state, :history, :last_transition,
+           :transition_to!, :transition_to, :in_state?, to: :state_machine
 end
 ```
 #### Using PostgreSQL JSON column


### PR DESCRIPTION
This makes it easier to copy and paste and give each machine a nice set of behaviour.