### PR TITLE
#358 cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## Upcoming breaking changes in v5
+
+- Remove pollution of methods when including `Statesman::Adapters::ActiveRecordQueries`
+  [@isaacseymour](https://github.com/gocardless/statesman/pull/358)
+  Change
+  ```ruby
+    include Statesman::Adapters::ActiveRecordQueries
+    def self.initial_state
+      :initial
+    end
+    def self.transition_class
+      MyTransition
+    end
+  ```
+  to
+  ```ruby
+    include Statesman::Adapters::ActiveRecordQueries[
+      initial_state: :inital,
+      transition_class: MyTransition
+    ]
+  ```
+- Drop support for older Rubies and Rails versions
+
 ## v4.1.2, 17th August 2019
 
 - Add support for Rails 6 [@greysteil](https://github.com/gocardless/statesman/pull/360)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ protection.
 To get started, just add Statesman to your `Gemfile`, and then run `bundle`:
 
 ```ruby
-gem 'statesman', '~> 3.4.1'
+gem 'statesman', '~> 4.1.2'
 ```
 
 ## Usage

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -1,32 +1,6 @@
 module Statesman
   module Adapters
     module ActiveRecordQueries
-      def self.check_missing_methods!(base)
-        missing_methods = %i[transition_class initial_state].
-          reject { |method| base.respond_to?(method) }
-        return if missing_methods.none?
-
-        raise NotImplementedError,
-              "#{missing_methods.join(', ')} method(s) should be defined on " \
-              "the model. Alternatively, use the new form of `extend " \
-              "Statesman::Adapters::ActiveRecordQueries[" \
-              "transition_class: MyTransition, " \
-              "initial_state: :some_state]`"
-      end
-
-      def self.included(base)
-        check_missing_methods!(base)
-
-        base.include(
-          ClassMethods.new(
-            transition_class: base.transition_class,
-            initial_state: base.initial_state,
-            most_recent_transition_alias: base.try(:most_recent_transition_alias),
-            transition_name: base.try(:transition_name),
-          ),
-        )
-      end
-
       def self.[](**args)
         ClassMethods.new(**args)
       end

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -3,7 +3,7 @@ module Statesman
     module ActiveRecordQueries
       def self.check_missing_methods!(base)
         missing_methods = %i[transition_class initial_state].
-          reject { |_method| base.respond_to?(:method) }
+          reject { |method| base.respond_to?(method) }
         return if missing_methods.none?
 
         raise NotImplementedError,
@@ -62,7 +62,7 @@ module Statesman
 
         def define_in_state(base, query_builder)
           base.define_singleton_method(:in_state) do |*states|
-            states = states.flatten.map(&:to_s)
+            states = states.flatten
 
             joins(most_recent_transition_join).
               where(query_builder.states_where(states), states)
@@ -71,7 +71,7 @@ module Statesman
 
         def define_not_in_state(base, query_builder)
           base.define_singleton_method(:not_in_state) do |*states|
-            states = states.flatten.map(&:to_s)
+            states = states.flatten
 
             joins(most_recent_transition_join).
               where("NOT (#{query_builder.states_where(states)})", states)

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -1,15 +1,15 @@
 require "spec_helper"
 
 describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
-  def configure_old(klass, transition_class)
-    klass.define_singleton_method(:transition_class) { transition_class }
-    klass.define_singleton_method(:initial_state) { :initial }
-    klass.send(:include, described_class)
-  end
-
-  def configure_new(klass, transition_class)
-    klass.send(:include, described_class[transition_class: transition_class,
-                                         initial_state: :initial])
+  def configure(klass, transition_class, **more)
+    klass.send(
+      :include,
+      described_class[
+        transition_class: transition_class,
+        initial_state: :initial,
+        **more
+      ],
+    )
   end
 
   before do
@@ -19,9 +19,17 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
     prepare_other_transitions_table
 
     Statesman.configure { storage_adapter(Statesman::Adapters::ActiveRecord) }
+
+    configure(MyActiveRecordModel, MyActiveRecordModelTransition, **extra_options1)
+    configure(OtherActiveRecordModel, OtherActiveRecordModelTransition)
+
+    MyActiveRecordModel.send(:has_one, :other_active_record_model)
+    OtherActiveRecordModel.send(:belongs_to, :my_active_record_model)
   end
 
   after { Statesman.configure { storage_adapter(Statesman::Adapters::Memory) } }
+
+  let(:extra_options1) { {} }
 
   let!(:model) do
     model = MyActiveRecordModel.create
@@ -44,172 +52,123 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
     model
   end
 
-  shared_examples "testing methods" do
-    before do
-      if config_type == :old
-        configure_old(MyActiveRecordModel, MyActiveRecordModelTransition)
-        configure_old(OtherActiveRecordModel, OtherActiveRecordModelTransition)
-      elsif config_type == :new
-        configure_new(MyActiveRecordModel, MyActiveRecordModelTransition)
-        configure_new(OtherActiveRecordModel, OtherActiveRecordModelTransition)
-      else
-        raise "Unknown config type #{config_type}"
-      end
+  describe ".in_state" do
+    context "given a single state" do
+      subject { MyActiveRecordModel.in_state(:succeeded) }
 
-      MyActiveRecordModel.send(:has_one, :other_active_record_model)
-      OtherActiveRecordModel.send(:belongs_to, :my_active_record_model)
+      it { is_expected.to include model }
+      it { is_expected.to_not include other_model }
     end
 
-    describe ".in_state" do
-      context "given a single state" do
-        subject { MyActiveRecordModel.in_state(:succeeded) }
+    context "given multiple states" do
+      subject { MyActiveRecordModel.in_state(:succeeded, :failed) }
 
-        it { is_expected.to include model }
-        it { is_expected.to_not include other_model }
-      end
-
-      context "given multiple states" do
-        subject { MyActiveRecordModel.in_state(:succeeded, :failed) }
-
-        it { is_expected.to include model }
-        it { is_expected.to include other_model }
-      end
-
-      context "given the initial state" do
-        subject { MyActiveRecordModel.in_state(:initial) }
-
-        it { is_expected.to include initial_state_model }
-        it { is_expected.to include returned_to_initial_model }
-      end
-
-      context "given an array of states" do
-        subject { MyActiveRecordModel.in_state(%i[succeeded failed]) }
-
-        it { is_expected.to include model }
-        it { is_expected.to include other_model }
-      end
-
-      context "merging two queries" do
-        subject do
-          MyActiveRecordModel.in_state(:succeeded).
-            joins(:other_active_record_model).
-            merge(OtherActiveRecordModel.in_state(:initial))
-        end
-
-        it { is_expected.to be_empty }
-      end
+      it { is_expected.to include model }
+      it { is_expected.to include other_model }
     end
 
-    describe ".not_in_state" do
-      context "given a single state" do
-        subject { MyActiveRecordModel.not_in_state(:failed) }
+    context "given the initial state" do
+      subject { MyActiveRecordModel.in_state(:initial) }
 
-        it { is_expected.to include model }
-        it { is_expected.to_not include other_model }
-      end
-
-      context "given multiple states" do
-        subject(:not_in_state) { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
-
-        it do
-          expect(not_in_state).to match_array([initial_state_model,
-                                               returned_to_initial_model])
-        end
-      end
-
-      context "given an array of states" do
-        subject(:not_in_state) { MyActiveRecordModel.not_in_state(%i[succeeded failed]) }
-
-        it do
-          expect(not_in_state).to match_array([initial_state_model,
-                                               returned_to_initial_model])
-        end
-      end
+      it { is_expected.to include initial_state_model }
+      it { is_expected.to include returned_to_initial_model }
     end
 
-    context "with a custom name for the transition association" do
-      before do
-        # Switch to using OtherActiveRecordModelTransition, so the existing
-        # relation with MyActiveRecordModelTransition doesn't interfere with
-        # this spec.
-        MyActiveRecordModel.send(:has_many,
-                                 :custom_name,
-                                 class_name: "OtherActiveRecordModelTransition")
+    context "given an array of states" do
+      subject { MyActiveRecordModel.in_state(%i[succeeded failed]) }
 
-        MyActiveRecordModel.class_eval do
-          def self.transition_class
-            OtherActiveRecordModelTransition
-          end
-        end
-      end
-
-      describe ".in_state" do
-        subject(:query) { MyActiveRecordModel.in_state(:succeeded) }
-
-        specify { expect { query }.to_not raise_error }
-      end
+      it { is_expected.to include model }
+      it { is_expected.to include other_model }
     end
 
-    context "after_commit transactional integrity" do
-      before do
-        MyStateMachine.class_eval do
-          cattr_accessor(:after_commit_callback_executed) { false }
-
-          after_transition(from: :initial, to: :succeeded, after_commit: true) do
-            # This leaks state in a testable way if transactional integrity is broken.
-            MyStateMachine.after_commit_callback_executed = true
-          end
-        end
+    context "merging two queries" do
+      subject do
+        MyActiveRecordModel.in_state(:succeeded).
+          joins(:other_active_record_model).
+          merge(OtherActiveRecordModel.in_state(:initial))
       end
 
-      after do
-        MyStateMachine.class_eval do
-          callbacks[:after_commit] = []
-        end
-      end
+      it { is_expected.to be_empty }
+    end
+  end
 
-      let!(:model) do
-        MyActiveRecordModel.create
-      end
+  describe ".not_in_state" do
+    context "given a single state" do
+      subject { MyActiveRecordModel.not_in_state(:failed) }
 
-      # rubocop:disable RSpec/ExampleLength
+      it { is_expected.to include model }
+      it { is_expected.to_not include other_model }
+    end
+
+    context "given multiple states" do
+      subject(:not_in_state) { MyActiveRecordModel.not_in_state(:succeeded, :failed) }
+
       it do
-        expect do
-          ActiveRecord::Base.transaction do
-            model.state_machine.transition_to!(:succeeded)
-            raise ActiveRecord::Rollback
-          end
-        end.to_not change(MyStateMachine, :after_commit_callback_executed)
+        expect(not_in_state).to match_array([initial_state_model,
+                                             returned_to_initial_model])
       end
-      # rubocop:enable RSpec/ExampleLength
+    end
+
+    context "given an array of states" do
+      subject(:not_in_state) { MyActiveRecordModel.not_in_state(%i[succeeded failed]) }
+
+      it do
+        expect(not_in_state).to match_array([initial_state_model,
+                                             returned_to_initial_model])
+      end
     end
   end
 
-  context "using old configuration method" do
-    let(:config_type) { :old }
+  context "with a custom name for the transition association" do
+    let(:extra_options1) { { transition_class: OtherActiveRecordModelTransition } }
 
-    include_examples "testing methods"
-  end
-
-  context "using new configuration method" do
-    let(:config_type) { :new }
-
-    include_examples "testing methods"
-  end
-
-  context "with no association with the transition class" do
     before do
-      class UnknownModelTransition < OtherActiveRecordModelTransition; end
-
-      configure_old(MyActiveRecordModel, UnknownModelTransition)
+      # Switch to using OtherActiveRecordModelTransition, so the existing
+      # relation with MyActiveRecordModelTransition doesn't interfere with
+      # this spec.
+      MyActiveRecordModel.send(:has_many,
+                               :custom_name,
+                               class_name: "OtherActiveRecordModelTransition")
     end
 
     describe ".in_state" do
       subject(:query) { MyActiveRecordModel.in_state(:succeeded) }
 
-      it "raises a helpful error" do
-        expect { query }.to raise_error(Statesman::MissingTransitionAssociation)
+      specify { expect { query }.to_not raise_error }
+    end
+  end
+
+  context "after_commit transactional integrity" do
+    before do
+      MyStateMachine.class_eval do
+        cattr_accessor(:after_commit_callback_executed) { false }
+
+        after_transition(from: :initial, to: :succeeded, after_commit: true) do
+          # This leaks state in a testable way if transactional integrity is broken.
+          MyStateMachine.after_commit_callback_executed = true
+        end
       end
     end
+
+    after do
+      MyStateMachine.class_eval do
+        callbacks[:after_commit] = []
+      end
+    end
+
+    let!(:model) do
+      MyActiveRecordModel.create
+    end
+
+    # rubocop:disable RSpec/ExampleLength
+    it do
+      expect do
+        ActiveRecord::Base.transaction do
+          model.state_machine.transition_to!(:succeeded)
+          raise ActiveRecord::Rollback
+        end
+      end.to_not change(MyStateMachine, :after_commit_callback_executed)
+    end
+    # rubocop:enable RSpec/ExampleLength
   end
 end


### PR DESCRIPTION
Sorry for being slow. Changes:
- removing duplicated `map(&:to_s)`
- adding migration details to changelog
- drop backwards-compatibility - can remove this commit; but I think it's less confusing to just force a (very simple) migration.