### PR TITLE
Fix typo in `check_missing_methods!`

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -3,7 +3,7 @@ module Statesman
     module ActiveRecordQueries
       def self.check_missing_methods!(base)
         missing_methods = %i[transition_class initial_state].
-          reject { |_method| base.respond_to?(:method) }
+          reject { |m| base.respond_to?(m) }
         return if missing_methods.none?
 
         raise NotImplementedError,

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -212,4 +212,32 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
       end
     end
   end
+
+  describe "check_missing_methods!" do
+    subject(:check_missing_methods!) { described_class.check_missing_methods!(base) }
+
+    context "when base has no missing methods" do
+      let(:base) do
+        Class.new do
+          def self.transition_class; end
+
+          def self.initial_state; end
+        end
+      end
+
+      it "does not raise an error" do
+        expect { check_missing_methods! }.to_not raise_exception(NotImplementedError)
+      end
+    end
+
+    context "when base has missing methods" do
+      let(:base) do
+        Class.new
+      end
+
+      it "raises an error" do
+        expect { check_missing_methods! }.to raise_exception(NotImplementedError)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Small typo meant that this method wasn't actually checking if methods were implemented.

Fixes https://github.com/gocardless/statesman/issues/369