### PR TITLE
Change transition failed error to explicitly include to / from states

### DIFF
--- a/lib/statesman/exceptions.rb
+++ b/lib/statesman/exceptions.rb
@@ -3,7 +3,18 @@ module Statesman
   class InvalidTransitionError < StandardError; end
   class InvalidCallbackError < StandardError; end
   class GuardFailedError < StandardError; end
-  class TransitionFailedError < StandardError; end
+  class TransitionFailedError < StandardError
+    def initialize(from, to)
+      @from = from
+      @to = to
+    end
+
+    attr_reader :from, :to
+
+    def message
+      "Cannot transition from '#{from}' to '#{to}'"
+    end
+  end
   class TransitionConflictError < StandardError; end
   class MissingTransitionAssociation < StandardError; end
 

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -283,10 +283,7 @@ module Statesman
       to   = to_s_or_nil(options[:to])
 
       successors = self.class.successors[from] || []
-      unless successors.include?(to)
-        raise TransitionFailedError,
-              "Cannot transition from '#{from}' to '#{to}'"
-      end
+      raise TransitionFailedError.new(from, to) unless successors.include?(to)
 
       # Call all guards, they raise exceptions if they fail
       guards_for(from: from, to: to).each do |guard|

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -57,7 +57,11 @@ describe Statesman::Machine do
         expect(instance).
           to receive(:transition_to).once.
           and_raise(StandardError)
-        transition_state rescue nil # rubocop:disable RescueModifier
+        begin
+          transition_state
+        rescue StandardError
+          nil
+        end
       end
 
       it "re-raises the exception" do
@@ -86,7 +90,11 @@ describe Statesman::Machine do
             to receive(:transition_to).
             exactly(retry_attempts + 1).times.
             and_raise(Statesman::TransitionConflictError)
-          transition_state rescue nil # rubocop:disable RescueModifier
+          begin
+            transition_state
+          rescue StandardError
+            nil
+          end
         end
 
         it "re-raises the conflict" do
@@ -619,8 +627,12 @@ describe Statesman::Machine do
 
     context "when the state cannot be transitioned to" do
       it "raises an error" do
+        # Hardcoding error message here to ensure backward
+        # compatibility as people may have been parsing the string
+        # to figure out the transitions involved.
         expect { instance.transition_to!(:z) }.
-          to raise_error(Statesman::TransitionFailedError)
+          to raise_error(Statesman::TransitionFailedError,
+                         "Cannot transition from 'x' to 'z'")
       end
     end
 


### PR DESCRIPTION
Make the from / to states in the TransitionFailedError accessible to avoid parsing strings to determine which state transition failed.  

Allows the recipient to make more informed decisions when a state transition fails. For example if we're trying to transition to the same state due to a race condition we should take a different action than if we're transitioning to something that is invalid as a result of a programming error.

Maintain backwards compatibility with those who parsed the exception to get the transition states by maintaining the same error message.