### PR TITLE
v4.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v4.1.4, 11th November 2019
+
+- Reverts the breaking changes from [PR#358](https://github.com/gocardless/statesman/pull/358) & `v4.1.3` that where included in the last minor release. If you have changed your code to work with these changes `v5.0.0` will be a copy of `v4.1.3` with a bugfix applied.
+
 ## v4.1.3, 6th November 2019
 
 - Add accessible from / to state attributes on the `TransitionFailedError` to avoid parsing strings [@ahjmorton](https://github.com/gocardless/statesman/pull/367)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ protection.
 To get started, just add Statesman to your `Gemfile`, and then run `bundle`:
 
 ```ruby
-gem 'statesman', '~> 3.4.1'
+gem 'statesman', '~> 4.1.4'
 ```
 
 ## Usage

--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,3 +1,3 @@
 module Statesman
-  VERSION = "4.1.3".freeze
+  VERSION = "4.1.4".freeze
 end


### PR DESCRIPTION
`4.1.3` was accidently released as a patch change instead of major. 

To correct things we are going to release a new patch release without the breaking change, and people pinned to minor versions should jump 2 upgrades missing the potentially broken state.

We'll then re-add the change and release it as a major version that is equal to `4.1.3` (except with the addition of https://github.com/gocardless/statesman/pull/364 which fixes a typo in the initial implementation of this.)