### PR TITLE
Change extend to include

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -8,7 +8,7 @@ module Statesman
 
         raise NotImplementedError,
               "#{missing_methods.join(', ')} method(s) should be defined on " \
-              "the model. Alternatively, use the new form of `extend " \
+              "the model. Alternatively, use the new form of `include " \
               "Statesman::Adapters::ActiveRecordQueries[" \
               "transition_class: MyTransition, " \
               "initial_state: :some_state]`"


### PR DESCRIPTION
This message just bit me when upgrading to Statesman 5.0.

The message says you need to extend Statesman::Adapters::ActiveRecordQueries, but you should use include instead.