### PR TITLE
Pass exception to after_failure callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,28 +257,28 @@ transition has been committed to the database.
 
 #### `Machine.after_transition_failure`
 ```ruby
-Machine.after_transition_failure(from: :some_state, to: :another_state) do |object|
-  Logger.info("transition failed for #{object.id}")
+Machine.after_transition_failure(from: :some_state, to: :another_state) do |object, exception|
+  Logger.info("transition to #{exception.to} failed for #{object.id}")
 end
 ```
 Define a callback to run if `Statesman::TransitionFailedError` is raised
 during the execution of transition callbacks. `to` and `from`
 parameters are optional, a nil parameter means run after all transitions.
-The model object is passed as an argument to the callback.
+The model object, and exception are passed as arguments to the callback.
 This is executed outside of the transaction wrapping other callbacks.
 If using `transition!` the exception is re-raised after these callbacks are
 executed.
 
 #### `Machine.after_guard_failure`
 ```ruby
-Machine.after_guard_failure(from: :some_state, to: :another_state) do |object|
-  Logger.info("guard failed for #{object.id}")
+Machine.after_guard_failure(from: :some_state, to: :another_state) do |object, exception|
+  Logger.info("guard failed during transition to #{exception.to} for #{object.id}")
 end
 ```
 Define a callback to run if `Statesman::GuardFailedError` is raised
 during the execution of guard callbacks. `to` and `from`
 parameters are optional, a nil parameter means run after all transitions.
-The model object is passed as an argument to the callback.
+The model object, and exception are passed as arguments to the callback.
 This is executed outside of the transaction wrapping other callbacks.
 If using `transition!` the exception is re-raised after these callbacks are
 executed.

--- a/lib/statesman/exceptions.rb
+++ b/lib/statesman/exceptions.rb
@@ -2,7 +2,7 @@ module Statesman
   class InvalidStateError < StandardError; end
   class InvalidTransitionError < StandardError; end
   class InvalidCallbackError < StandardError; end
-  class GuardFailedError < StandardError; end
+
   class TransitionFailedError < StandardError
     def initialize(from, to)
       @from = from
@@ -15,6 +15,20 @@ module Statesman
       "Cannot transition from '#{from}' to '#{to}'"
     end
   end
+
+  class GuardFailedError < StandardError
+    def initialize(from, to)
+      @from = from
+      @to = to
+    end
+
+    attr_reader :from, :to
+
+    def message
+      "Guard on transition from: '#{from}' to '#{to}' returned false"
+    end
+  end
+
   class TransitionConflictError < StandardError; end
   class MissingTransitionAssociation < StandardError; end
 

--- a/lib/statesman/guard.rb
+++ b/lib/statesman/guard.rb
@@ -4,10 +4,7 @@ require_relative "exceptions"
 module Statesman
   class Guard < Callback
     def call(*args)
-      unless super(*args)
-        raise GuardFailedError,
-              "Guard on transition from: '#{from}' to '#{to}' returned false"
-      end
+      raise GuardFailedError.new(from, to) unless super(*args)
     end
   end
 end

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -721,7 +721,7 @@ describe Statesman::Machine do
 
             it "calls the failure callback" do
               expect(guard_failure_cb).to receive(:call).once.with(
-                my_model, nil
+                my_model, instance_of(Statesman::GuardFailedError)
               ).and_return(guard_failure_result)
               expect { instance.transition_to!(:y) }.
                 to raise_error(Statesman::GuardFailedError)
@@ -740,8 +740,9 @@ describe Statesman::Machine do
         end
 
         it "raises and exception and calls the callback" do
-          expect(transition_failed_cb).to receive(:call).once.
-            with(my_model, nil).and_return(true)
+          expect(transition_failed_cb).to receive(:call).once.with(
+            my_model, instance_of(Statesman::TransitionFailedError)
+          ).and_return(true)
           expect { instance.transition_to!(:z) }.
             to raise_error(Statesman::TransitionFailedError)
         end


### PR DESCRIPTION
- The exceptions now contain attributes denoting the `from` and `to`
state which caused the exceptions. This is useful for the failure
callbacks as they don't currently know the state that was being
transitioned to.
- Pass the exceptions to the callbacks so they can make use of this
information.