### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,4 +499,4 @@ end
 
 ---
 
-GoCardless ♥ open source. If you do too, come [join us](https://gocardless.com/about/jobs/software-engineer).
+GoCardless ♥ open source. If you do too, come [join us](https://gocardless.com/about/careers/).


### PR DESCRIPTION
Although "https://gocardless.com/about/jobs" correctly re-directs to "https://boards.greenhouse.io/gocardless", the current link "https://gocardless.com/about/jobs/software-engineer" goes to a 404 page:

> <img width="973" alt="圖片" src="https://user-images.githubusercontent.com/12410942/71303967-b2fde000-23fa-11ea-91af-9c8d52841c43.png">
