### PR TITLE
Drop official support for Rails 4.2, 5.0 and 5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,89 +31,11 @@ references:
       path: /tmp/test-results
 
 jobs:
-  build-ruby249-rails-429-mysql:
-    docker:
-      - image: circleci/ruby:2.4.9-node
-        environment:
-          - RAILS_VERSION=4.2.9
-          - DATABASE_URL=mysql2://root@127.0.0.1/statesman_test
-          - DATABASE_DEPENDENCY_PORT=3306
-      - image: circleci/mysql:5.7.18
-        environment:
-          - MYSQL_ALLOW_EMPTY_PASSWORD=true
-          - MYSQL_USER=root
-          - MYSQL_PASSWORD=
-          - MYSQL_DATABASE=statesman_test
-    steps: *steps
-  build-ruby249-rails-429-postgres:
-    docker:
-      - image: circleci/ruby:2.4.9-node
-        environment:
-          - RAILS_VERSION=4.2.9
-          - DATABASE_URL=postgres://postgres@localhost/statesman_test
-          - DATABASE_DEPENDENCY_PORT=5432
-      - image: circleci/postgres:9.6
-        environment:
-          - POSTGRES_USER=postgres
-          - POSTGRES_DB=statesman_test
-    steps: *steps
-  build-ruby249-rails-505-mysql:
-    docker:
-      - image: circleci/ruby:2.4.9-node
-        environment:
-          - RAILS_VERSION=5.0.5
-          - DATABASE_URL=mysql2://root@127.0.0.1/statesman_test
-          - DATABASE_DEPENDENCY_PORT=3306
-      - image: circleci/mysql:5.7.18
-        environment:
-          - MYSQL_ALLOW_EMPTY_PASSWORD=true
-          - MYSQL_USER=root
-          - MYSQL_PASSWORD=
-          - MYSQL_DATABASE=statesman_test
-    steps: *steps
-  build-ruby249-rails-505-postgres:
-    docker:
-      - image: circleci/ruby:2.4.9-node
-        environment:
-          - RAILS_VERSION=5.0.5
-          - DATABASE_URL=postgres://postgres@localhost/statesman_test
-          - DATABASE_DEPENDENCY_PORT=5432
-      - image: circleci/postgres:9.6
-        environment:
-          - POSTGRES_USER=postgres
-          - POSTGRES_DB=statesman_test
-    steps: *steps
-  build-ruby249-rails-513-mysql:
-    docker:
-      - image: circleci/ruby:2.4.9-node
-        environment:
-          - RAILS_VERSION=5.1.3
-          - DATABASE_URL=mysql2://root@127.0.0.1/statesman_test
-          - DATABASE_DEPENDENCY_PORT=3306
-      - image: circleci/mysql:5.7.18
-        environment:
-          - MYSQL_ALLOW_EMPTY_PASSWORD=true
-          - MYSQL_USER=root
-          - MYSQL_PASSWORD=
-          - MYSQL_DATABASE=statesman_test
-    steps: *steps
-  build-ruby249-rails-513-postgres:
-    docker:
-      - image: circleci/ruby:2.4.9-node
-        environment:
-          - RAILS_VERSION=5.1.3
-          - DATABASE_URL=postgres://postgres@localhost/statesman_test
-          - DATABASE_DEPENDENCY_PORT=5432
-      - image: circleci/postgres:9.6
-        environment:
-          - POSTGRES_USER=postgres
-          - POSTGRES_DB=statesman_test
-    steps: *steps
-  build-ruby265-rails-600-mysql:
+  build-ruby265-rails-602-mysql:
     docker:
       - image: circleci/ruby:2.6.5-node
         environment:
-          - RAILS_VERSION=6.0.0
+          - RAILS_VERSION=6.0.2
           - DATABASE_URL=mysql2://root@127.0.0.1/statesman_test
           - DATABASE_DEPENDENCY_PORT=3306
       - image: circleci/mysql:5.7.18
@@ -123,11 +45,11 @@ jobs:
           - MYSQL_PASSWORD=
           - MYSQL_DATABASE=statesman_test
     steps: *steps
-  build-ruby265-rails-600-postgres:
+  build-ruby265-rails-602-postgres:
     docker:
       - image: circleci/ruby:2.6.5-node
         environment:
-          - RAILS_VERSION=6.0.0
+          - RAILS_VERSION=6.0.2
           - DATABASE_URL=postgres://postgres@localhost/statesman_test
           - DATABASE_DEPENDENCY_PORT=5432
       - image: circleci/postgres:9.6
@@ -162,11 +84,11 @@ jobs:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
     steps: *steps
-  build-ruby249-rails-523-mysql:
+  build-ruby249-rails-524-mysql:
     docker:
       - image: circleci/ruby:2.4.9-node
         environment:
-          - RAILS_VERSION=5.2.3
+          - RAILS_VERSION=5.2.4
           - DATABASE_URL=mysql2://root@127.0.0.1/statesman_test
           - DATABASE_DEPENDENCY_PORT=3306
       - image: circleci/mysql:5.7.18
@@ -176,11 +98,11 @@ jobs:
           - MYSQL_PASSWORD=
           - MYSQL_DATABASE=statesman_test
     steps: *steps
-  build-ruby249-rails-523-postgres:
+  build-ruby249-rails-524-postgres:
     docker:
       - image: circleci/ruby:2.4.9-node
         environment:
-          - RAILS_VERSION=5.2.3
+          - RAILS_VERSION=5.2.4
           - DATABASE_URL=postgres://postgres@localhost/statesman_test
           - DATABASE_DEPENDENCY_PORT=5432
       - image: circleci/postgres:9.6
@@ -194,15 +116,9 @@ workflows:
   version: 2
   tests:
     jobs:
-      - build-ruby249-rails-429-mysql
-      - build-ruby249-rails-429-postgres
-      - build-ruby249-rails-505-mysql
-      - build-ruby249-rails-505-postgres
-      - build-ruby249-rails-513-mysql
-      - build-ruby249-rails-513-postgres
-      - build-ruby249-rails-523-mysql
-      - build-ruby249-rails-523-postgres
-      - build-ruby265-rails-600-mysql
-      - build-ruby265-rails-600-postgres
+      - build-ruby249-rails-524-mysql
+      - build-ruby249-rails-524-postgres
+      - build-ruby265-rails-602-mysql
+      - build-ruby265-rails-602-postgres
       - build-ruby265-rails-master-mysql
       - build-ruby265-rails-master-postgres

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
+## v7.0.0, 8th Jan 2020
+
+**Breaking changes**
+
+- Drop official support for Rails 4.2, 5.0 and 5.1, following our [compatibility
+  policy](https://github.com/gocardless/statesman/blob/master/docs/COMPATIBILITY.md).
+
 ## v6.0.0, 20th December 2019
 
 **Breaking changes**
 
 - Drop official support for Ruby 2.2 and 2.3 following our [compatibility
   policy](https://github.com/gocardless/statesman/blob/master/docs/COMPATIBILITY.md).
-
 
 ## v5.2.0, 17th December 2019
 

--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Statesman
-  VERSION = "6.0.0"
+  VERSION = "7.0.0"
 end

--- a/statesman.gemspec
+++ b/statesman.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mysql2", ">= 0.4", "< 0.6"
   spec.add_development_dependency "pg", "~> 0.18"
   spec.add_development_dependency "pry"
-  spec.add_development_dependency "rails", ">= 3.2"
+  spec.add_development_dependency "rails", ">= 5.2"
   spec.add_development_dependency "rake", "~> 13.0.0"
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "rspec-its", "~> 1.1"


### PR DESCRIPTION
As per our compatibility policy, this also bumps the major version (to `7.0`).