### PR TITLE
Suppress a Ruby 2.7's warning

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -195,8 +195,8 @@ module Statesman
     end
 
     class ActiveRecordAfterCommitWrap
-      def initialize
-        @callback = Proc.new
+      def initialize(&block)
+        @callback = block
         @connection = ::ActiveRecord::Base.connection
       end
 


### PR DESCRIPTION
This PR suppresses the following Ruby 2.7's warning.

```console
% ruby -v
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-darwin17]
% bundle exec rake
/Users/koic/src/github.com/gocardless/statesman/lib/statesman/adapters/active_record.rb:199:
warning: Capturing the given block using Proc.new is deprecated; use
`&block` instead
```