### PR TITLE
Call super in custom errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v7.1.0, 10th Feb 2020
+
+- Fix `to_s` on `TransitionFailedError` & `GuardFailedError`. `.message` and
+    `.to_s` diverged when `from` and `to` accessors where added in v4.1.3
+
 ## v7.0.1, 8th Jan 2020
 
 - Fix deprecation warning with Ruby 2.7 [#386](https://github.com/gocardless/statesman/pull/386)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ protection.
 To get started, just add Statesman to your `Gemfile`, and then run `bundle`:
 
 ```ruby
-gem 'statesman', '~> 7.0.1'
+gem 'statesman', '~> 7.1.0'
 ```
 
 ## Usage

--- a/lib/statesman/exceptions.rb
+++ b/lib/statesman/exceptions.rb
@@ -4,16 +4,21 @@ module Statesman
   class InvalidStateError < StandardError; end
   class InvalidTransitionError < StandardError; end
   class InvalidCallbackError < StandardError; end
+  class TransitionConflictError < StandardError; end
+  class MissingTransitionAssociation < StandardError; end
 
   class TransitionFailedError < StandardError
     def initialize(from, to)
       @from = from
       @to = to
+      super(_message)
     end
 
     attr_reader :from, :to
 
-    def message
+    private
+
+    def _message
       "Cannot transition from '#{from}' to '#{to}'"
     end
   end
@@ -22,17 +27,17 @@ module Statesman
     def initialize(from, to)
       @from = from
       @to = to
+      super(_message)
     end
 
     attr_reader :from, :to
 
-    def message
+    private
+
+    def _message
       "Guard on transition from: '#{from}' to '#{to}' returned false"
     end
   end
-
-  class TransitionConflictError < StandardError; end
-  class MissingTransitionAssociation < StandardError; end
 
   class UnserializedMetadataError < StandardError
     def initialize(transition_class_name)

--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Statesman
-  VERSION = "7.0.1"
+  VERSION = "7.1.0"
 end

--- a/spec/statesman/exceptions_spec.rb
+++ b/spec/statesman/exceptions_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Statesman do
+  describe "InvalidStateError" do
+    subject(:error) { Statesman::InvalidStateError.new }
+
+    its(:message) { is_expected.to eq("Statesman::InvalidStateError") }
+    its "string matches its message" do
+      expect(error.to_s).to eq(error.message)
+    end
+  end
+
+  describe "InvalidTransitionError" do
+    subject(:error) { Statesman::InvalidTransitionError.new }
+
+    its(:message) { is_expected.to eq("Statesman::InvalidTransitionError") }
+    its "string matches its message" do
+      expect(error.to_s).to eq(error.message)
+    end
+  end
+
+  describe "InvalidCallbackError" do
+    subject(:error) { Statesman::InvalidTransitionError.new }
+
+    its(:message) { is_expected.to eq("Statesman::InvalidTransitionError") }
+    its "string matches its message" do
+      expect(error.to_s).to eq(error.message)
+    end
+  end
+
+  describe "TransitionConflictError" do
+    subject(:error) { Statesman::TransitionConflictError.new }
+
+    its(:message) { is_expected.to eq("Statesman::TransitionConflictError") }
+    its "string matches its message" do
+      expect(error.to_s).to eq(error.message)
+    end
+  end
+
+  describe "MissingTransitionAssociation" do
+    subject(:error) { Statesman::MissingTransitionAssociation.new }
+
+    its(:message) { is_expected.to eq("Statesman::MissingTransitionAssociation") }
+    its "string matches its message" do
+      expect(error.to_s).to eq(error.message)
+    end
+  end
+
+  describe "TransitionFailedError" do
+    subject(:error) { Statesman::TransitionFailedError.new("from", "to") }
+
+    its(:message) { is_expected.to eq("Cannot transition from 'from' to 'to'") }
+    its "string matches its message" do
+      expect(error.to_s).to eq(error.message)
+    end
+  end
+
+  describe "GuardFailedError" do
+    subject(:error) { Statesman::GuardFailedError.new("from", "to") }
+
+    its(:message) do
+      is_expected.to eq("Guard on transition from: 'from' to 'to' returned false")
+    end
+    its "string matches its message" do
+      expect(error.to_s).to eq(error.message)
+    end
+  end
+
+  describe "UnserializedMetadataError" do
+    subject(:error) { Statesman::UnserializedMetadataError.new("foo") }
+
+    its(:message) { is_expected.to match(/foo#metadata is not serialized/) }
+    its "string matches its message" do
+      expect(error.to_s).to eq(error.message)
+    end
+  end
+
+  describe "IncompatibleSerializationError" do
+    subject(:error) { Statesman::IncompatibleSerializationError.new("foo") }
+
+    its(:message) { is_expected.to match(/foo#metadata column type cannot be json/) }
+    its "string matches its message" do
+      expect(error.to_s).to eq(error.message)
+    end
+  end
+end


### PR DESCRIPTION
We are doing this for some of the errors but not all and the change
means that `to_s` now does not function as expected.

Calling super should return the error messages to normal