### PR TITLE
Fix Postgres test setup failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,7 @@ jobs:
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
+          - POSTGRES_PASSWORD=statesman
     steps: *steps
 
   build-ruby265-rails-602-mysql:
@@ -83,6 +84,7 @@ jobs:
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
+          - POSTGRES_PASSWORD=statesman
     steps: *steps
   build-ruby265-rails-master-mysql:
     docker:
@@ -110,6 +112,7 @@ jobs:
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
+          - POSTGRES_PASSWORD=statesman
     steps: *steps
 
   build-ruby270-rails-602-mysql:
@@ -137,6 +140,7 @@ jobs:
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
+          - POSTGRES_PASSWORD=statesman
     steps: *steps
   build-ruby270-rails-master-mysql:
     docker:
@@ -164,6 +168,7 @@ jobs:
         environment:
           - POSTGRES_USER=postgres
           - POSTGRES_DB=statesman_test
+          - POSTGRES_PASSWORD=statesman
     steps: *steps
 
 workflows:


### PR DESCRIPTION
All postgres tests are currently failing with the following:
```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD to a non-empty value for the
       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
       You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
       connections without a password. This is *not* recommended.
       See PostgreSQL documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
Exited with code 1
```
