### PR TITLE
Handle transitions differently for MySQL

### DIFF
--- a/lib/statesman.rb
+++ b/lib/statesman.rb
@@ -25,9 +25,14 @@ module Statesman
   def self.configure(&block)
     config = Config.new(block)
     @storage_adapter = config.adapter_class
+    @mysql_gaplock_protection = config.mysql_gaplock_protection
   end
 
   def self.storage_adapter
     @storage_adapter || Adapters::Memory
+  end
+
+  def self.mysql_gaplock_protection?
+    @mysql_gaplock_protection
   end
 end

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -127,7 +127,7 @@ module Statesman
       def update_most_recents(most_recent_id)
         transitions = transitions_for_parent
         last_or_current = transitions.where(id: most_recent_id).or(
-          transitions.where(most_recent: true)
+          transitions.where(most_recent: true),
         )
 
         last_or_current.update_all(
@@ -250,7 +250,7 @@ module Statesman
         return nil if column.nil?
 
         [
-          column, ::ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.now,
+          column, ::ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.now
         ]
       end
     end

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -74,19 +74,26 @@ module Statesman
         ::ActiveRecord::Base.transaction(requires_new: true) do
           @observer.execute(:before, from, to, transition)
 
-          # We save the transition first with most_recent falsy, then mark most_recent
-          # true after to avoid letting MySQL acquire a next-key lock which can cause
-          # deadlocks.
-          #
-          # To avoid an additional query, we manually adjust the most_recent attribute on
-          # our transition assuming that update_most_recents will have set it to true.
-          transition.save!
+          if db_mysql?
+            # We save the transition first with most_recent falsy, then mark most_recent
+            # true after to avoid letting MySQL acquire a next-key lock which can cause
+            # deadlocks.
+            #
+            # To avoid an additional query, we manually adjust the most_recent attribute
+            # on our transition assuming that update_most_recents will have set it to true
 
-          unless update_most_recents(transition.id) > 0
-            raise ActiveRecord::Rollback, "failed to update most_recent"
+            transition.save!
+
+            unless update_most_recents(transition.id).positive?
+              raise ActiveRecord::Rollback, "failed to update most_recent"
+            end
+
+            transition.assign_attributes(most_recent: true)
+          else
+            update_most_recents
+            transition.assign_attributes(most_recent: true)
+            transition.save!
           end
-
-          transition.assign_attributes(most_recent: true)
 
           @last_transition = transition
           @observer.execute(:after, from, to, transition)
@@ -98,17 +105,12 @@ module Statesman
       # rubocop:enable Metrics/MethodLength
 
       def default_transition_attributes(to, metadata)
-        transition_attributes = { to_state: to,
-                                  sort_key: next_sort_key,
-                                  metadata: metadata }
-
-        # see comment on `unset_old_most_recent` method
-        if transition_class.columns_hash["most_recent"].null == false
-          transition_attributes[:most_recent] = false
-        else
-          transition_attributes[:most_recent] = nil
-        end
-        transition_attributes
+        {
+          to_state: to,
+          sort_key: next_sort_key,
+          metadata: metadata,
+          most_recent: not_most_recent_value,
+        }
       end
 
       def add_after_commit_callback(from, to, transition)
@@ -125,18 +127,10 @@ module Statesman
 
       # Sets the given transition most_recent = t while unsetting the most_recent of any
       # previous transitions.
-      def update_most_recents(most_recent_id) # rubocop:disable Metrics/AbcSize
+      def update_most_recents(most_recent_id = nil)
         update = build_arel_manager(::Arel::UpdateManager)
         update.table(transition_table)
-
-        update.where(
-          transition_table[parent_join_foreign_key.to_sym].eq(parent_model.id).and(
-            transition_table[:id].eq(most_recent_id).or(
-              transition_table[:most_recent].eq(true),
-            ),
-          ),
-        )
-
+        update.where(most_recent_transitions(most_recent_id))
         update.set(build_most_recents_update_all_values(most_recent_id))
 
         # MySQL will validate index constraints across the intermediate result of an
@@ -144,7 +138,23 @@ module Statesman
         # most_recent before setting the new row to be true.
         update.order(transition_table[:most_recent].desc) if db_mysql?
 
-        ::ActiveRecord::Base.connection.exec_update(update.to_sql)
+        ::ActiveRecord::Base.connection.update(update.to_sql)
+      end
+
+      def most_recent_transitions(most_recent_id = nil)
+        if most_recent_id
+          transitions_of_parent.and(
+            transition_table[:id].eq(most_recent_id).or(
+              transition_table[:most_recent].eq(true),
+            ),
+          )
+        else
+          transitions_of_parent.and(transition_table[:most_recent].eq(true))
+        end
+      end
+
+      def transitions_of_parent
+        transition_table[parent_join_foreign_key.to_sym].eq(parent_model.id)
       end
 
       # Generates update_all Arel values that will touch the updated timestamp (if valid
@@ -162,32 +172,35 @@ module Statesman
       #        , updated_at = '...'
       #      ...
       #
-      # rubocop:disable Metrics/MethodLength
-      def build_most_recents_update_all_values(most_recent_id)
-        values = [
+      def build_most_recents_update_all_values(most_recent_id = nil)
+        [
           [
             transition_table[:most_recent],
-            Arel::Nodes::SqlLiteral.new(
-              Arel::Nodes::Case.new.
-                when(transition_table[:id].eq(most_recent_id)).then(true).
-                else(not_most_recent_value).to_sql,
-            ),
+            Arel::Nodes::SqlLiteral.new(most_recent_value(most_recent_id)),
           ],
-        ]
+        ].tap do |values|
+          # Only if we support the updated at timestamps should we add this column to the
+          # update
+          updated_column, updated_at = updated_column_and_timestamp
 
-        # Only if we support the updated at timestamps should we add this column to the
-        # update
-        updated_column, updated_at = updated_timestamp
-        if updated_column
-          values << [
-            transition_table[updated_column.to_sym],
-            updated_at,
-          ]
+          if updated_column
+            values << [
+              transition_table[updated_column.to_sym],
+              updated_at,
+            ]
+          end
         end
-
-        values
       end
-      # rubocop:enable Metrics/MethodLength
+
+      def most_recent_value(most_recent_id)
+        if most_recent_id
+          Arel::Nodes::Case.new.
+            when(transition_table[:id].eq(most_recent_id)).then(db_true).
+            else(not_most_recent_value).to_sql
+        else
+          Arel::Nodes::SqlLiteral.new(not_most_recent_value)
+        end
+      end
 
       # Provide a wrapper for constructing an update manager which handles a breaking API
       # change in Arel as we move into Rails >6.0.
@@ -199,19 +212,6 @@ module Statesman
         else
           manager.new(::ActiveRecord::Base)
         end
-      end
-
-      # Check whether the `most_recent` column allows null values. If it doesn't, set old
-      # records to `false`, otherwise, set them to `NULL`.
-      #
-      # Some conditioning here is required to support databases that don't support partial
-      # indexes. By doing the conditioning on the column, rather than Rails' opinion of
-      # whether the database supports partial indexes, we're robust to DBs later adding
-      # support for partial indexes.
-      def not_most_recent_value
-        return db_false if transition_class.columns_hash["most_recent"].null == false
-
-        nil
       end
 
       def next_sort_key
@@ -269,8 +269,8 @@ module Statesman
         end
       end
 
-      # updated_timestamp should return [column_name, value]
-      def updated_timestamp
+      # updated_column_and_timestamp should return [column_name, value]
+      def updated_column_and_timestamp
         # TODO: Once we've set expectations that transition classes should conform to
         # the interface of Adapters::ActiveRecordTransition as a breaking change in the
         # next major version, we can stop calling `#respond_to?` first and instead
@@ -310,6 +310,19 @@ module Statesman
           transition_class.columns_hash["most_recent"],
         )
         ::ActiveRecord::Base.connection.quote(value)
+      end
+
+      # Check whether the `most_recent` column allows null values. If it doesn't, set old
+      # records to `false`, otherwise, set them to `NULL`.
+      #
+      # Some conditioning here is required to support databases that don't support partial
+      # indexes. By doing the conditioning on the column, rather than Rails' opinion of
+      # whether the database supports partial indexes, we're robust to DBs later adding
+      # support for partial indexes.
+      def not_most_recent_value
+        return db_false if transition_class.columns_hash["most_recent"].null == false
+
+        nil
       end
     end
 

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -5,9 +5,6 @@ require_relative "../exceptions"
 module Statesman
   module Adapters
     class ActiveRecord
-      attr_reader :transition_class
-      attr_reader :parent_model
-
       JSON_COLUMN_TYPES = %w[json jsonb].freeze
 
       def self.database_supports_partial_indexes?
@@ -29,11 +26,14 @@ module Statesman
         end
 
         @transition_class = transition_class
+        @transition_table = transition_class.arel_table
         @parent_model = parent_model
         @observer = observer
         @association_name =
           options[:association_name] || @transition_class.table_name
       end
+
+      attr_reader :transition_class, :transition_table, :parent_model
 
       def create(from, to, metadata = {})
         create_transition(from.to_s, to.to_s, metadata)
@@ -81,6 +81,7 @@ module Statesman
           # To avoid an additional query, we manually adjust the most_recent attribute on
           # our transition assuming that update_most_recents will have set it to true.
           transition.save!
+
           unless update_most_recents(transition.id) > 0
             raise ActiveRecord::Rollback, "failed to update most_recent"
           end
@@ -124,25 +125,31 @@ module Statesman
 
       # Sets the given transition most_recent = t while unsetting the most_recent of any
       # previous transitions.
-      def update_most_recents(most_recent_id)
-        transitions = transitions_for_parent
+      def update_most_recents(most_recent_id) # rubocop:disable Metrics/AbcSize
+        update = Arel::UpdateManager.new
+        update.table(transition_table)
 
-        # TODO: Once support for Rails 4 is dropped this can be replaced with
-        # transitions.where(id: most_recent_id).or(transitions.where(most_recent: true)
-        last_or_current = transitions.where(
-          "#{transition_class.table_name}.id = #{most_recent_id} "\
-          "OR #{transition_class.table_name}.most_recent = "\
-          "#{::ActiveRecord::Base.connection.quote(true)}",
+        update.where(
+          transition_table[parent_join_foreign_key.to_sym].eq(parent_model.id).and(
+            transition_table[:id].eq(most_recent_id).or(
+              transition_table[:most_recent].eq(true),
+            ),
+          ),
         )
 
-        last_or_current.update_all(
-          build_most_recents_update_all(most_recent_id),
-        )
+        update.set(build_most_recents_update_all_values(most_recent_id))
+
+        # MySQL will validate index constraints across the intermediate result of an
+        # update. This means we must order our update to deactivate the previous
+        # most_recent before setting the new row to be true.
+        update.order(transition_table[:most_recent].desc) if db_mysql?
+
+        ::ActiveRecord::Base.connection.exec_update(update.to_sql)
       end
 
-      # Generates update_all parameters that will touch the updated timestamp (if valid
-      # for this model) and ensure only the transition with the most_recent_id has
-      # most_recent set to true.
+      # Generates update_all Arel values that will touch the updated timestamp (if valid
+      # for this model) and set most_recent to true only for the transition with a
+      # matching most_recent ID.
       #
       # This is quite nasty, but combines two updates (set all most_recent = f, set
       # current most_recent = t) into one, which helps improve transition performance
@@ -155,19 +162,32 @@ module Statesman
       #        , updated_at = '...'
       #      ...
       #
-      def build_most_recents_update_all(most_recent_id)
-        clause = "most_recent = "\
-                 "(case when id = ? then #{db_true} else #{not_most_recent_value} end)"
-        parameters = [most_recent_id]
+      # rubocop:disable Metrics/MethodLength
+      def build_most_recents_update_all_values(most_recent_id)
+        values = [
+          [
+            transition_table[:most_recent],
+            Arel::Nodes::SqlLiteral.new(
+              Arel::Nodes::Case.new.
+                when(transition_table[:id].eq(most_recent_id)).then(true).
+                else(not_most_recent_value).to_sql,
+            ),
+          ],
+        ]
 
+        # Only if we support the updated at timestamps should we add this column to the
+        # update
         updated_column, updated_at = updated_timestamp
         if updated_column
-          clause += ", #{updated_column} = ?"
-          parameters.push(updated_at)
+          values << [
+            transition_table[updated_column.to_sym],
+            updated_at,
+          ]
         end
 
-        [clause, *parameters]
+        values
       end
+      # rubocop:enable Metrics/MethodLength
 
       # Check whether the `most_recent` column allows null values. If it doesn't, set old
       # records to `false`, otherwise, set them to `NULL`.
@@ -179,7 +199,7 @@ module Statesman
       def not_most_recent_value
         return db_false if transition_class.columns_hash["most_recent"].null == false
 
-        "NULL"
+        nil
       end
 
       def next_sort_key
@@ -258,6 +278,10 @@ module Statesman
         [
           column, ::ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.now
         ]
+      end
+
+      def db_mysql?
+        ::ActiveRecord::Base.connection.adapter_name.downcase.starts_with?("mysql")
       end
 
       def db_true

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -126,8 +126,12 @@ module Statesman
       # previous transitions.
       def update_most_recents(most_recent_id)
         transitions = transitions_for_parent
-        last_or_current = transitions.where(id: most_recent_id).or(
-          transitions.where(most_recent: true),
+
+        # TODO: Once support for Rails 4 is dropped this can be replaced with
+        # transitions.where(id: most_recent_id).or(transitions.where(most_recent: true)
+        last_or_current = transitions.where(
+          "#{transition_class.table_name}.id = #{most_recent_id} "\
+          "OR #{transition_class.table_name}.most_recent = #{db_true}",
         )
 
         last_or_current.update_all(
@@ -252,6 +256,10 @@ module Statesman
         [
           column, ::ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.now
         ]
+      end
+
+      def db_true
+        ::ActiveRecord::Base.connection.quote(true)
       end
     end
 

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -70,14 +70,16 @@ module Statesman
                                   sort_key: next_sort_key,
                                   metadata: metadata }
 
-        transition_attributes[:most_recent] = true
-
         transition = transitions_for_parent.build(transition_attributes)
 
         ::ActiveRecord::Base.transaction(requires_new: true) do
           @observer.execute(:before, from, to, transition)
-          unset_old_most_recent
+          # We save the transition first, and mark it as
+          # most_recent after to avoid letting MySQL put a
+          # next-key lock which could cause deadlocks.
           transition.save!
+          unset_old_most_recent
+          transition.update!(most_recent: true)
           @last_transition = transition
           @observer.execute(:after, from, to, transition)
           add_after_commit_callback(from, to, transition)

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -131,7 +131,8 @@ module Statesman
         # transitions.where(id: most_recent_id).or(transitions.where(most_recent: true)
         last_or_current = transitions.where(
           "#{transition_class.table_name}.id = #{most_recent_id} "\
-          "OR #{transition_class.table_name}.most_recent = #{db_true}",
+          "OR #{transition_class.table_name}.most_recent = "\
+          "#{::ActiveRecord::Base.connection.quote(true)}",
         )
 
         last_or_current.update_all(
@@ -155,8 +156,9 @@ module Statesman
       #      ...
       #
       def build_most_recents_update_all(most_recent_id)
-        clause = "most_recent = (case when id = ? then ? else ? end)"
-        parameters = [most_recent_id, true, not_most_recent_value]
+        clause = "most_recent = "\
+                 "(case when id = ? then #{db_true} else #{not_most_recent_value} end)"
+        parameters = [most_recent_id]
 
         updated_column, updated_at = updated_timestamp
         if updated_column
@@ -175,9 +177,9 @@ module Statesman
       # whether the database supports partial indexes, we're robust to DBs later adding
       # support for partial indexes.
       def not_most_recent_value
-        return false if transition_class.columns_hash["most_recent"].null == false
+        return db_false if transition_class.columns_hash["most_recent"].null == false
 
-        nil
+        "NULL"
       end
 
       def next_sort_key
@@ -259,7 +261,19 @@ module Statesman
       end
 
       def db_true
-        ::ActiveRecord::Base.connection.quote(true)
+        value = ::ActiveRecord::Base.connection.type_cast(
+          true,
+          transition_class.columns_hash["most_recent"],
+        )
+        ::ActiveRecord::Base.connection.quote(value)
+      end
+
+      def db_false
+        value = ::ActiveRecord::Base.connection.type_cast(
+          false,
+          transition_class.columns_hash["most_recent"],
+        )
+        ::ActiveRecord::Base.connection.quote(value)
       end
     end
 

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -65,6 +65,7 @@ module Statesman
 
       private
 
+      # rubocop:disable Metrics/MethodLength
       def create_transition(from, to, metadata)
         transition = transitions_for_parent.build(
           default_transition_attributes(to, metadata),
@@ -72,12 +73,20 @@ module Statesman
 
         ::ActiveRecord::Base.transaction(requires_new: true) do
           @observer.execute(:before, from, to, transition)
-          # We save the transition first, and mark it as
-          # most_recent after to avoid letting MySQL put a
-          # next-key lock which could cause deadlocks.
+
+          # We save the transition first with most_recent falsy, then mark most_recent
+          # true after to avoid letting MySQL acquire a next-key lock which can cause
+          # deadlocks.
+          #
+          # To avoid an additional query, we manually adjust the most_recent attribute on
+          # our transition assuming that update_most_recents will have set it to true.
           transition.save!
-          unset_old_most_recent
-          transition.update!(most_recent: true)
+          unless update_most_recents(transition.id) > 0
+            raise ActiveRecord::Rollback, "failed to update most_recent"
+          end
+
+          transition.assign_attributes(most_recent: true)
+
           @last_transition = transition
           @observer.execute(:after, from, to, transition)
           add_after_commit_callback(from, to, transition)
@@ -85,6 +94,7 @@ module Statesman
 
         transition
       end
+      # rubocop:enable Metrics/MethodLength
 
       def default_transition_attributes(to, metadata)
         transition_attributes = { to_state: to,
@@ -112,21 +122,58 @@ module Statesman
         parent_model.send(@association_name)
       end
 
-      def unset_old_most_recent
-        most_recent = transitions_for_parent.where(most_recent: true)
+      # Sets the given transition most_recent = t while unsetting the most_recent of any
+      # previous transitions.
+      def update_most_recents(most_recent_id)
+        transitions = transitions_for_parent
+        last_or_current = transitions.where(id: most_recent_id).or(
+          transitions.where(most_recent: true)
+        )
 
-        # Check whether the `most_recent` column allows null values. If it
-        # doesn't, set old records to `false`, otherwise, set them to `NULL`.
-        #
-        # Some conditioning here is required to support databases that don't
-        # support partial indexes. By doing the conditioning on the column,
-        # rather than Rails' opinion of whether the database supports partial
-        # indexes, we're robust to DBs later adding support for partial indexes.
-        if transition_class.columns_hash["most_recent"].null == false
-          most_recent.update_all(with_updated_timestamp(most_recent: false))
-        else
-          most_recent.update_all(with_updated_timestamp(most_recent: nil))
+        last_or_current.update_all(
+          build_most_recents_update_all(most_recent_id),
+        )
+      end
+
+      # Generates update_all parameters that will touch the updated timestamp (if valid
+      # for this model) and ensure only the transition with the most_recent_id has
+      # most_recent set to true.
+      #
+      # This is quite nasty, but combines two updates (set all most_recent = f, set
+      # current most_recent = t) into one, which helps improve transition performance
+      # especially when database latency is significant.
+      #
+      # The SQL this can help produce looks like:
+      #
+      #   update transitions
+      #      set most_recent = (case when id = 'PA123' then TRUE else FALSE end)
+      #        , updated_at = '...'
+      #      ...
+      #
+      def build_most_recents_update_all(most_recent_id)
+        clause = "most_recent = (case when id = ? then ? else ? end)"
+        parameters = [most_recent_id, true, not_most_recent_value]
+
+        updated_column, updated_at = updated_timestamp
+        if updated_column
+          clause += ", #{updated_column} = ?"
+          parameters.push(updated_at)
         end
+
+        [clause, *parameters]
+      end
+
+      # Check whether the `most_recent` column allows null values. If it doesn't, set old
+      # records to `false`, otherwise, set them to `NULL`.
+      #
+      # Some conditioning here is required to support databases that don't support partial
+      # indexes. By doing the conditioning on the column, rather than Rails' opinion of
+      # whether the database supports partial indexes, we're robust to DBs later adding
+      # support for partial indexes.
+      def not_most_recent_value
+        return false if transition_class.columns_hash["most_recent"].null == false
+
+        nil
       end
 
       def next_sort_key
@@ -184,7 +231,8 @@ module Statesman
         end
       end
 
-      def with_updated_timestamp(params)
+      # updated_timestamp should return [column_name, value]
+      def updated_timestamp
         # TODO: Once we've set expectations that transition classes should conform to
         # the interface of Adapters::ActiveRecordTransition as a breaking change in the
         # next major version, we can stop calling `#respond_to?` first and instead
@@ -198,15 +246,12 @@ module Statesman
                    ActiveRecordTransition::DEFAULT_UPDATED_TIMESTAMP_COLUMN
                  end
 
-        return params if column.nil?
+        # No updated timestamp column, don't return anything
+        return nil if column.nil?
 
-        timestamp = if ::ActiveRecord::Base.default_timezone == :utc
-                      Time.now.utc
-                    else
-                      Time.now
-                    end
-
-        params.merge(column => timestamp)
+        [
+          column, ::ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.now,
+        ]
       end
     end
 

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -66,11 +66,9 @@ module Statesman
       private
 
       def create_transition(from, to, metadata)
-        transition_attributes = { to_state: to,
-                                  sort_key: next_sort_key,
-                                  metadata: metadata }
-
-        transition = transitions_for_parent.build(transition_attributes)
+        transition = transitions_for_parent.build(
+          default_transition_attributes(to, metadata),
+        )
 
         ::ActiveRecord::Base.transaction(requires_new: true) do
           @observer.execute(:before, from, to, transition)
@@ -86,6 +84,20 @@ module Statesman
         end
 
         transition
+      end
+
+      def default_transition_attributes(to, metadata)
+        transition_attributes = { to_state: to,
+                                  sort_key: next_sort_key,
+                                  metadata: metadata }
+
+        # see comment on `unset_old_most_recent` method
+        if transition_class.columns_hash["most_recent"].null == false
+          transition_attributes[:most_recent] = false
+        else
+          transition_attributes[:most_recent] = nil
+        end
+        transition_attributes
       end
 
       def add_after_commit_callback(from, to, transition)

--- a/lib/statesman/config.rb
+++ b/lib/statesman/config.rb
@@ -5,14 +5,35 @@ require_relative "exceptions"
 
 module Statesman
   class Config
-    attr_reader :adapter_class
+    attr_reader :adapter_class, :mysql_gaplock_protection
 
     def initialize(block = nil)
       instance_eval(&block) unless block.nil?
     end
 
     def storage_adapter(adapter_class)
+      # If our adapter class suggests we're using mysql, enable gaplock protection by
+      # default.
+      enable_mysql_gaplock_protection if mysql_adapter?(adapter_class)
+
       @adapter_class = adapter_class
+    end
+
+    def enable_mysql_gaplock_protection
+      @mysql_gaplock_protection = true
+    end
+
+    private
+
+    def mysql_adapter?(adapter_class)
+      adapter_name = adapter_name(adapter_class)
+      return false unless adapter_name
+
+      adapter_name.start_with?("mysql")
+    end
+
+    def adapter_name(adapter_class)
+      adapter_class.respond_to?(:adapter_name) && adapter_class&.adapter_name
     end
   end
 end

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -20,7 +20,9 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
     prepare_other_model_table
     prepare_other_transitions_table
 
-    Statesman.configure { storage_adapter(Statesman::Adapters::ActiveRecord) }
+    Statesman.configure do
+      storage_adapter(Statesman::Adapters::ActiveRecord)
+    end
   end
 
   after { Statesman.configure { storage_adapter(Statesman::Adapters::Memory) } }

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -9,9 +9,19 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
   before do
     prepare_model_table
     prepare_transitions_table
+
+    MyActiveRecordModelTransition.serialize(:metadata, JSON)
+
+    Statesman.configure do
+      # Rubocop requires described_class to be used, but this block
+      # is instance_eval'd and described_class won't be defined
+      # rubocop:disable RSpec/DescribedClass
+      storage_adapter(Statesman::Adapters::ActiveRecord)
+      # rubocop:enable RSpec/DescribedClass
+    end
   end
 
-  before { MyActiveRecordModelTransition.serialize(:metadata, JSON) }
+  after { Statesman.configure { storage_adapter(Statesman::Adapters::Memory) } }
 
   let(:observer) { double(Statesman::Machine, execute: nil) }
   let(:model) { MyActiveRecordModel.create(current_state: :pending) }

--- a/statesman.gemspec
+++ b/statesman.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "gc_ruboconfig", "~> 2.3.9"
   spec.add_development_dependency "mysql2", ">= 0.4", "< 0.6"
-  spec.add_development_dependency "pg", "~> 0.18"
+  spec.add_development_dependency "pg", ">= 0.18", "<= 1.1"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rails", ">= 5.2"
   spec.add_development_dependency "rake", "~> 13.0.0"


### PR DESCRIPTION
To avoid a gap lock with MySQL, first insert the new transition with most_recent=false and then flip the values for the latest two transitions in order.

Includes https://github.com/gocardless/statesman/pull/350 and https://github.com/gocardless/statesman/pull/353