### PR TITLE
fix: bump version

### DIFF
--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Statesman
-  VERSION = "7.1.0"
+  VERSION = "7.2.0"
 end


### PR DESCRIPTION
v7.2.0 was tagged in:

https://github.com/gocardless/statesman/commit/c11e03921867d46ee43edf473deadc5e5576d242