### PR TITLE
Use correct Arel for null

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -316,6 +316,10 @@ module Statesman
         ::ActiveRecord::Base.connection.quote(value)
       end
 
+      def db_null
+        Arel::Nodes::SqlLiteral.new("NULL")
+      end
+
       # Check whether the `most_recent` column allows null values. If it doesn't, set old
       # records to `false`, otherwise, set them to `NULL`.
       #
@@ -326,7 +330,7 @@ module Statesman
       def not_most_recent_value
         return db_false if transition_class.columns_hash["most_recent"].null == false
 
-        nil
+        db_null
       end
     end
 


### PR DESCRIPTION
In https://github.com/gocardless/statesman/issues/408 we saw that due to the changes in https://github.com/gocardless/statesman/pull/399 we weren't handling null values correctly when creating new transitions. Arel cannot cast `nil` to `null` and we see 
```
> Arel::Nodes::SqlLiteral.new(nil)
TypeError: no implicit conversion of nil into String
from (pry):1:in `initialize'
```