### PR TITLE
Gem metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@
 - [Gem Metadata](https://guides.rubygems.org/specification-reference/#metadata)
   to make finding changes between releases even easier.
 
+## v7.3.0, 24th August 2020
+
+### Changed
+
+- Use correct Arel for null [#409](https://github.com/gocardless/statesman/pull/#409)
+
+## v7.2.0, 19th May 2020
+
+### Changed
+
+- Set non-empty password for postgres tests [#398](https://github.com/gocardless/statesman/pull/#398)
+- Handle transitions differently for MySQL [#399](https://github.com/gocardless/statesman/pull/#399)
+- pg requirement from >= 0.18, <= 1.1 to >= 0.18, <= 1.3 [#400](https://github.com/gocardless/statesman/pull/#400)
+- Lazily enable mysql gaplock protection [#402](https://github.com/gocardless/statesman/pull/#402)
+
 ## v7.1.0, 10th Feb 2020
 
 - Fix `to_s` on `TransitionFailedError` & `GuardFailedError`. `.message` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Added
+
+- [Gem Metadata](https://guides.rubygems.org/specification-reference/#metadata)
+  to make finding changes between releases even easier.
+
 ## v7.1.0, 10th Feb 2020
 
 - Fix `to_s` on `TransitionFailedError` & `GuardFailedError`. `.message` and

--- a/statesman.gemspec
+++ b/statesman.gemspec
@@ -4,6 +4,8 @@ lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "statesman/version"
 
+GITHUB_URL = "https://github.com/gocardless/statesman"
+
 Gem::Specification.new do |spec|
   spec.name          = "statesman"
   spec.version       = Statesman::VERSION
@@ -11,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["developers@gocardless.com"]
   spec.description   = "A statesman-like state machine library"
   spec.summary       = spec.description
-  spec.homepage      = "https://github.com/gocardless/statesman"
+  spec.homepage      = GITHUB_URL
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
@@ -35,4 +37,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec_junit_formatter", "~> 0.4.0"
   spec.add_development_dependency "sqlite3", "~> 1.4.2"
   spec.add_development_dependency "timecop", "~> 0.9.1"
+
+  spec.metadata = {
+    "bug_tracker_uri" => "#{GITHUB_URL}/issues",
+    "changelog_uri" => "#{GITHUB_URL}/blob/master/CHANGELOG.md",
+    "documentation_uri" => "#{GITHUB_URL}/blob/master/README.md",
+    "homepage_uri" => GITHUB_URL,
+    "source_code_uri" => GITHUB_URL,
+  }
 end


### PR DESCRIPTION
### Context

Performing a regular `bundle update` (using [unwrappr](https://rubygems.org/gems/unwrappr)), statesman updated from v7.2.0 to v7.3.0 but it wasn't obvious what had changed.

### Change

 - Add [Gem Metadata](https://guides.rubygems.org/specification-reference/#metadata to make finding changes between releases even easier.
 - Backfill changelog to include v7.2.0 and v7.3.0

### Considerations

 - v7.3.0 is not currently tagged