### PR TITLE
Require ruby >=2.3 in gemspec

### DIFF
--- a/statesman.gemspec
+++ b/statesman.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.2"
+  spec.required_ruby_version = ">= 2.3"
 
   spec.add_development_dependency "ammeter", "~> 1.1"
   spec.add_development_dependency "bundler", "~> 2.1.4"


### PR DESCRIPTION
Since the library uses the safe navigation operator, it is only present in ruby 2.3 and above.