### PR TITLE
Add #reset method to state machine and adapter interfaces #415

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -67,6 +67,10 @@ module Statesman
         end
       end
 
+      def reset
+        @last_transition = nil
+      end
+
       private
 
       # rubocop:disable Metrics/MethodLength

--- a/lib/statesman/adapters/memory.rb
+++ b/lib/statesman/adapters/memory.rb
@@ -37,6 +37,10 @@ module Statesman
         @history
       end
 
+      def reset
+        @history = []
+      end
+
       private
 
       def next_sort_key

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -257,6 +257,10 @@ module Statesman
       false
     end
 
+    def reset
+      @storage_adapter.reset
+    end
+
     private
 
     def adapter_class(transition_class)

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -355,6 +355,18 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
     end
   end
 
+  it "resets last with #reload" do
+    model.save!
+    ActiveRecord::Base.transaction do
+      model.state_machine.transition_to!(:succeeded)
+      model.state_machine.current_state
+      raise ActiveRecord::Rollback
+    end
+    expect(model.state_machine.current_state).to eq('succeeded')
+    model.reload
+    expect(model.state_machine.current_state).to eq('initial')
+  end
+
   context "with a namespaced model" do
     before do
       CreateNamespacedARModelMigration.migrate(:up)

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -359,12 +359,13 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
     model.save!
     ActiveRecord::Base.transaction do
       model.state_machine.transition_to!(:succeeded)
-      model.state_machine.current_state
+      # force to cache value in last_transition instance variable
+      expect(model.state_machine.current_state).to eq("succeeded")
       raise ActiveRecord::Rollback
     end
-    expect(model.state_machine.current_state).to eq('succeeded')
+    expect(model.state_machine.current_state).to eq("succeeded")
     model.reload
-    expect(model.state_machine.current_state).to eq('initial')
+    expect(model.state_machine.current_state).to eq("initial")
   end
 
   context "with a namespaced model" do

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -33,6 +33,11 @@ class MyActiveRecordModel < ActiveRecord::Base
   def metadata
     super || {}
   end
+
+  def reload(*)
+    state_machine.reset
+    super
+  end
 end
 
 class MyActiveRecordModelTransition < ActiveRecord::Base


### PR DESCRIPTION
It will allow to reset state machine `history` and `last` states with `#reload`.
Very useful in case of rollbacks.

Related to the issue  #415