### PR TITLE
Use AR Arel table to type cast booleans in order to avoid deprecation warning

### DIFF
--- a/lib/generators/statesman/generator_helpers.rb
+++ b/lib/generators/statesman/generator_helpers.rb
@@ -39,8 +39,16 @@ module Statesman
     end
 
     def mysql?
-      ActiveRecord::Base.configurations[Rails.env].
-        try(:[], "adapter").try(:match, /mysql/)
+      configuration.try(:[], "adapter").try(:match, /mysql/)
+    end
+
+    # [] is deprecated and will be removed in 6.2
+    def configuration
+      if ActiveRecord::Base.configurations.respond_to?(:configs_for)
+        ActiveRecord::Base.configurations.configs_for(env_name: Rails.env).first
+      else
+        ActiveRecord::Base.configurations[Rails.env]
+      end
     end
 
     def database_supports_partial_indexes?

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -305,23 +305,21 @@ module Statesman
       end
 
       def db_true
-        value = ::ActiveRecord::Base.connection.type_cast(
-          true,
-          transition_class.columns_hash["most_recent"],
-        )
-        ::ActiveRecord::Base.connection.quote(value)
+        ::ActiveRecord::Base.connection.quote(type_cast(true))
       end
 
       def db_false
-        value = ::ActiveRecord::Base.connection.type_cast(
-          false,
-          transition_class.columns_hash["most_recent"],
-        )
-        ::ActiveRecord::Base.connection.quote(value)
+        ::ActiveRecord::Base.connection.quote(type_cast(false))
       end
 
       def db_null
-        Arel::Nodes::SqlLiteral.new("NULL")
+        type_cast(nil)
+      end
+
+      # Type casting against a column is deprecated and will be removed in Rails 6.2.
+      # See https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11
+      def type_cast(value)
+        ::ActiveRecord::Base.connection.type_cast(value)
       end
 
       # Check whether the `most_recent` column allows null values. If it doesn't, set old


### PR DESCRIPTION
```
DEPRECATION WARNING: Passing a column to `quote` has been deprecated. It is only used for type casting, which should be handled elsewhere. See https://github.com/rails/arel/commit/6160bfbda1d1781c3b08a33ec4955f170e95be11 for more information. (called from update_most_recents at /Users/eproulx/code/statesman/lib/statesman/adapters/active_record.rb:144)
Arel performing automatic type casting is deprecated, and will be removed in Arel 8.0. If you are seeing this, it is because you are manually passing a value to an Arel predicate, and the `Arel::Table` object was constructed manually. The easiest way to remove this warning is to use an `Arel::Table` object returned from calling `arel_table` on an ActiveRecord::Base subclass.

If you're certain the value is already of the right type, change `attribute.eq(value)` to `attribute.eq(Arel::Nodes::Quoted.new(value))` (you will be able to remove that in Arel 8.0, it is only required to silence this deprecation warning).

You can also silence this warning globally by setting `$arel_silence_type_casting_deprecation` to `true`. (Do NOT do this if you are a library author)

If you are passing user input to a predicate, you must either give an appropriate type caster object to the `Arel::Table`, or manually cast the value before passing it to Arel.
```
also
```
DEPRECATION WARNING: Passing a column to `quote` has been deprecated. It
is only used for type casting, which should be handled elsewhere.
```

https://github.com/gocardless/statesman/issues/403