### PR TITLE
Support relationships that doesn't use `id` as a Primary Key

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -104,7 +104,7 @@ module Statesman
 
         def most_recent_transition_join
           "LEFT OUTER JOIN #{model_table} AS #{most_recent_transition_alias} " \
-             "ON #{model.table_name}.id = " \
+             "ON #{model.table_name}.#{model_primary_key} = " \
                   "#{most_recent_transition_alias}.#{model_foreign_key} " \
              "AND #{most_recent_transition_alias}.most_recent = #{db_true}"
         end
@@ -125,6 +125,10 @@ module Statesman
           raise MissingTransitionAssociation,
                 "Could not find has_many association between #{self.class} " \
                 "and #{transition_class}."
+        end
+
+        def model_primary_key
+          transition_reflection.active_record_primary_key
         end
 
         def model_foreign_key

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -154,6 +154,31 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
       end
     end
 
+    context "with a custom primary key for the model" do
+      before do
+        # Switch to using OtherActiveRecordModelTransition, so the existing
+        # relation with MyActiveRecordModelTransition doesn't interfere with
+        # this spec.
+        # Configure the relationship to use a different primary key,
+        MyActiveRecordModel.send(:has_many,
+                                 :custom_name,
+                                 class_name: "OtherActiveRecordModelTransition",
+                                 primary_key: :external_id)
+
+        MyActiveRecordModel.class_eval do
+          def self.transition_class
+            OtherActiveRecordModelTransition
+          end
+        end
+      end
+
+      describe ".in_state" do
+        subject(:query) { MyActiveRecordModel.in_state(:succeeded) }
+
+        specify { expect { query }.to_not raise_error }
+      end
+    end
+
     context "after_commit transactional integrity" do
       before do
         MyStateMachine.class_eval do


### PR DESCRIPTION
The convention of naming the Primary Key of a table as `id` is widespread 
on Rails applications and very useful. 
However, exceptions are also supported and widespread in Rails projects.

If we decide to model an _entity_ with a primary key named `external_id` instead of  just `id`,
the methods provided by Statesman::Adapters::ActiveRecordQueries stop working as expected.

Even worse, if the model has the column `id` and `external_id` it will use the `id` even when this column is not a primary key, which leads to a problem because the query result will be incorrect but it won't fail as an error.