### PR TITLE
Fix for `no implicit conversion of nil into String`

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -313,7 +313,7 @@ module Statesman
       end
 
       def db_null
-        type_cast(nil)
+        Arel::Nodes::SqlLiteral.new("NULL")
       end
 
       # Type casting against a column is deprecated and will be removed in Rails 6.2.


### PR DESCRIPTION
As part of https://github.com/gocardless/statesman/pull/421 we changed `db_null` in the AR adapter to type cast `nil`. This breaks for Postgres databases that have a nullable `most_recent` column. 

Fixes: https://github.com/gocardless/statesman/issues/424