### PR TITLE
Make sure failed transitions don't cause the current_state to change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## UNRELEASE
+
+### Changed
+
+- Fixed a bug where the `history` of a model was left in an incorrect state after a transition
+  conflict [#433](https://github.com/gocardless/statesman/pull/433)
+
 ## v8.0.0 6th January 2021
 
 ### Added
@@ -24,16 +31,16 @@
 
 ### Changed
 
-- Use correct Arel for null [#409](https://github.com/gocardless/statesman/pull/#409)
+- Use correct Arel for null [#409](https://github.com/gocardless/statesman/pull/409)
 
 ## v7.2.0, 19th May 2020
 
 ### Changed
 
-- Set non-empty password for postgres tests [#398](https://github.com/gocardless/statesman/pull/#398)
-- Handle transitions differently for MySQL [#399](https://github.com/gocardless/statesman/pull/#399)
-- pg requirement from >= 0.18, <= 1.1 to >= 0.18, <= 1.3 [#400](https://github.com/gocardless/statesman/pull/#400)
-- Lazily enable mysql gaplock protection [#402](https://github.com/gocardless/statesman/pull/#402)
+- Set non-empty password for postgres tests [#398](https://github.com/gocardless/statesman/pull/398)
+- Handle transitions differently for MySQL [#399](https://github.com/gocardless/statesman/pull/399)
+- pg requirement from >= 0.18, <= 1.1 to >= 0.18, <= 1.3 [#400](https://github.com/gocardless/statesman/pull/400)
+- Lazily enable mysql gaplock protection [#402](https://github.com/gocardless/statesman/pull/402)
 
 ## v7.1.0, 10th Feb 2020
 


### PR DESCRIPTION
When a transition conflict occurs, the `transitions_for_parent` still has the built (but not persisted!) new transition in it. This means that if you're in a `retry_conflicts` block you'll look at the `current_state` and see the wrong state! That's bad! So instead we reload the transitions, so that `current_state` and related methods are returning the correct value immediately, without doing a `force_reload`.