### PR TITLE
Deprecate ActiveRecord::Base.default_timezone

### DIFF
--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -304,8 +304,15 @@ module Statesman
         return nil if column.nil?
 
         [
-          column, ::ActiveRecord::Base.default_timezone == :utc ? Time.now.utc : Time.now
+          column, default_timezone == :utc ? Time.now.utc : Time.now
         ]
+      end
+
+      def default_timezone
+        # Rails 7 deprecates ActiveRecord::Base.default_timezone in favour of ActiveRecord.default_timezone
+        return ::ActiveRecord.default_timezone if ::ActiveRecord.respond_to?(:default_timezone)
+
+        ::ActiveRecord::Base.default_timezone
       end
 
       def mysql_gaplock_protection?


### PR DESCRIPTION
Rails 7.0 [deprecates](https://github.com/rails/rails/commit/c6e4dbeebbfa4ea2b6d50a2ffb75f707b68aabf4) `ActiveRecord::Base.default_timezone` in favour of `ActiveRecord.default_timezone`. Rails 7.1 will remove this method entirely. To prevent deprecation warnings in 7.0, the gem should default to the new method.