### PR TITLE
Updated the supported Ruby and Rails versions to match current support.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,15 +46,15 @@ references:
         path: /tmp/circle_artifacts/
 
   ruby_versions: &ruby_versions
-    - "2.5"
-    - "2.6"
     - "2.7"
     - "3.0"
+    - "3.1"
 
   rails_versions: &rails_versions
-    - "5.2.6"
+    - "5.2.7"
     - "6.0.4"
-    - "6.1.4"
+    - "6.1.5"
+    - "7.0.2"
     - "main"
 
   mysql_versions: &mysql_versions


### PR DESCRIPTION
For Ruby versions:
- Ruby 2.7 is in Security Maintenance
- Ruby 3.0 is in Normal Maintenance
- Ruby 3.1 is in Normal Maintenance

For Rails versions:
- Rails 5.2+ have security support

---

See:
- https://www.ruby-lang.org/en/downloads/branches/
- https://endoflife.date/rails