### PR TITLE
Added methods to remove states and transitions from state machines.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,12 @@ inherit_gem:
 
 AllCops:
   TargetRubyVersion: 3.0
+
+Metrics/AbcSize:
+  Max: 60
+
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+Metrics/PerceivedComplexity:
+  Max: 11

--- a/lib/statesman/machine.rb
+++ b/lib/statesman/machine.rb
@@ -42,6 +42,17 @@ module Statesman
         states << name
       end
 
+      def remove_state(state_name)
+        state_name = state_name.to_s
+
+        remove_transitions(from: state_name)
+        remove_transitions(to: state_name)
+        remove_callbacks(from: state_name)
+        remove_callbacks(to: state_name)
+
+        @states.delete(state_name.to_s)
+      end
+
       def successors
         @successors ||= {}
       end
@@ -68,6 +79,20 @@ module Statesman
         ([from] + to).each { |state| validate_state(state) }
 
         successors[from] += to
+      end
+
+      def remove_transitions(from: nil, to: nil)
+        raise ArgumentError, "Both from and to can't be nil!" if from.nil? && to.nil?
+        return if successors.nil?
+
+        if from.present?
+          @successors[from.to_s].delete(to.to_s) if to.present?
+          @successors.delete(from.to_s) if to.nil? || successors[from.to_s].empty?
+        elsif to.present?
+          @successors.
+            transform_values! { |to_states| to_states - [to.to_s] }.
+            filter! { |_from_state, to_states| to_states.any? }
+        end
       end
 
       def before_transition(options = {}, &block)
@@ -149,6 +174,33 @@ module Statesman
 
         callbacks[callback_type] <<
           callback_class.new(from: from, to: to, callback: block)
+      end
+
+      def remove_callbacks(from: nil, to: nil)
+        raise ArgumentError, "Both from and to can't be nil!" if from.nil? && to.nil?
+        return if callbacks.nil?
+
+        @callbacks.transform_values! do |callbacks|
+          filter_callbacks(callbacks, from: from, to: to)
+        end
+      end
+
+      def filter_callbacks(callbacks, from: nil, to: nil)
+        callbacks.filter_map do |callback|
+          next if callback.from == from && to.nil?
+
+          if callback.to.include?(to) && (from.nil? || callback.from == from)
+            next if callback.to == [to]
+
+            callback = Statesman::Callback.new({
+              from: callback.from,
+              to: callback.to - [to],
+              callback: callback.callback,
+            })
+          end
+
+          callback
+        end
       end
 
       def validate_callback_type_and_class(callback_type, callback_class)


### PR DESCRIPTION
Historically, when a state machine uses a template and wants to remove a
state or transition it will just set a guard that always returns false.
This isn't a particularly neat solution since the states and transitions
still exist on the state machine, and can make inspecting the internals
of the state machine return misleading information.

This change adds explicit methods to allow a state machine to delete
states or transitions. When a state is deleted, all related transitions
and callbacks will also be cleaned up as appropriate.