### PR TITLE
Add the source location of the Guard callback to GuardFailedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v10.1.0 10th March 2023
+
+### CHanged
+- Add the source location of the guard callback to `Statesman::GuardFailedError`
+
 ## v10.0.0 17th May 2022
 
 ### Changed

--- a/lib/statesman/exceptions.rb
+++ b/lib/statesman/exceptions.rb
@@ -28,13 +28,15 @@ module Statesman
   end
 
   class GuardFailedError < StandardError
-    def initialize(from, to)
+    def initialize(from, to, callback)
       @from = from
       @to = to
+      @callback = callback
       super(_message)
+      set_backtrace(callback.source_location.join(":")) if callback&.source_location
     end
 
-    attr_reader :from, :to
+    attr_reader :from, :to, :callback
 
     private
 

--- a/lib/statesman/guard.rb
+++ b/lib/statesman/guard.rb
@@ -6,7 +6,7 @@ require_relative "exceptions"
 module Statesman
   class Guard < Callback
     def call(*args)
-      raise GuardFailedError.new(from, to) unless super(*args)
+      raise GuardFailedError.new(from, to, callback) unless super(*args)
     end
   end
 end

--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Statesman
-  VERSION = "10.0.0"
+  VERSION = "10.1.0"
 end

--- a/spec/statesman/exceptions_spec.rb
+++ b/spec/statesman/exceptions_spec.rb
@@ -64,10 +64,16 @@ describe Statesman do
   end
 
   describe "GuardFailedError" do
-    subject(:error) { Statesman::GuardFailedError.new("from", "to") }
+    subject(:error) { Statesman::GuardFailedError.new("from", "to", callback) }
+
+    let(:callback) { -> { "hello" } }
 
     its(:message) do
       is_expected.to eq("Guard on transition from: 'from' to 'to' returned false")
+    end
+
+    its(:backtrace) do
+      is_expected.to eq([callback.source_location.join(":")])
     end
 
     its "string matches its message" do

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -935,10 +935,10 @@ describe Statesman::Machine do
       it { is_expected.to be(:some_state) }
     end
 
-    context "when it is unsuccesful" do
+    context "when it is unsuccessful" do
       before do
         allow(instance).to receive(:transition_to!).
-          and_raise(Statesman::GuardFailedError.new(:x, :some_state))
+          and_raise(Statesman::GuardFailedError.new(:x, :some_state, nil))
       end
 
       it { is_expected.to be_falsey }


### PR DESCRIPTION
Often it can be difficult to know _which_ guard failed, especially if
there are a lot of guards that may intersect.

```
Statesman::GuardFailedError: Guard on transition from: '' to '["bar"]' returned false
from /Users/joesouthan/foobar/app/state_machines/foobars.rb:98
```
