### PR TITLE
Update rspec-rails requirement from ~> 3.1 to ~> 6.0

### DIFF
--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -254,7 +254,7 @@ describe Statesman::Adapters::ActiveRecordQueries, active_record: true do
       end
 
       it "does not raise an error" do
-        expect { check_missing_methods! }.to_not raise_exception(NotImplementedError)
+        expect { check_missing_methods! }.to_not raise_exception
       end
     end
 

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -112,7 +112,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
   end
 
   describe "#create" do
-    subject { -> { create } }
+    subject(:transition) { create }
 
     let!(:adapter) do
       described_class.new(MyActiveRecordModelTransition, model, observer)
@@ -173,19 +173,17 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
           end
         end
 
-        it { is_expected.to raise_exception(ActiveRecord::RecordNotUnique) }
+        it { expect { transition }.to raise_exception(ActiveRecord::RecordNotUnique) }
       end
 
       context "other errors" do
         let(:error) { StandardError }
 
-        it { is_expected.to raise_exception(StandardError) }
+        it { expect { transition }.to raise_exception(StandardError) }
       end
     end
 
     describe "updating the most_recent column" do
-      subject { create }
-
       context "with no previous transition" do
         its(:most_recent) { is_expected.to eq(true) }
       end

--- a/spec/statesman/adapters/shared_examples.rb
+++ b/spec/statesman/adapters/shared_examples.rb
@@ -30,14 +30,14 @@ shared_examples_for "an adapter" do |adapter_class, transition_class, options = 
   end
 
   describe "#create" do
-    subject { -> { create } }
+    subject(:transition) { create }
 
     let(:from) { :x }
     let(:to) { :y }
     let(:there) { :z }
     let(:create) { adapter.create(from, to) }
 
-    it { is_expected.to change(adapter.history, :count).by(1) }
+    it { expect { transition }.to change(adapter.history, :count).by(1) }
 
     context "the new transition" do
       subject(:instance) { create }

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -28,7 +28,7 @@ describe Statesman::Machine do
   end
 
   describe ".remove_state" do
-    subject(:remove_state) { -> { machine.remove_state(:x) } }
+    subject(:remove_state) { machine.remove_state(:x) }
 
     before do
       machine.class_eval do
@@ -39,7 +39,7 @@ describe Statesman::Machine do
     end
 
     it "removes the state" do
-      expect(remove_state).
+      expect { remove_state }.
         to change(machine, :states).
         from(match_array(%w[x y z])).
         to(%w[y z])
@@ -49,7 +49,7 @@ describe Statesman::Machine do
       before { machine.transition from: :x, to: :y }
 
       it "removes the transition" do
-        expect(remove_state).
+        expect { remove_state }.
           to change(machine, :successors).
           from({ "x" => ["y"] }).
           to({})
@@ -59,7 +59,7 @@ describe Statesman::Machine do
         before { machine.transition from: :x, to: :z }
 
         it "removes all transitions" do
-          expect(remove_state).
+          expect { remove_state }.
             to change(machine, :successors).
             from({ "x" => %w[y z] }).
             to({})
@@ -71,7 +71,7 @@ describe Statesman::Machine do
       before { machine.transition from: :y, to: :x }
 
       it "removes the transition" do
-        expect(remove_state).
+        expect { remove_state }.
           to change(machine, :successors).
           from({ "y" => ["x"] }).
           to({})
@@ -81,7 +81,7 @@ describe Statesman::Machine do
         before { machine.transition from: :z, to: :x }
 
         it "removes all transitions" do
-          expect(remove_state).
+          expect { remove_state }.
             to change(machine, :successors).
             from({ "y" => ["x"], "z" => ["x"] }).
             to({})
@@ -104,7 +104,7 @@ describe Statesman::Machine do
       end
 
       it "removes the guard" do
-        expect(remove_state).
+        expect { remove_state }.
           to change(machine, :callbacks).
           from(a_hash_including(guards: match_array(guards))).
           to(a_hash_including(guards: []))
@@ -125,7 +125,7 @@ describe Statesman::Machine do
       end
 
       it "removes the guard" do
-        expect(remove_state).
+        expect { remove_state }.
           to change(machine, :callbacks).
           from(a_hash_including(guards: match_array(guards))).
           to(a_hash_including(guards: []))

--- a/statesman.gemspec
+++ b/statesman.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.1"
   spec.add_development_dependency "rspec-github", "~> 2.4.0"
   spec.add_development_dependency "rspec-its", "~> 1.1"
-  spec.add_development_dependency "rspec-rails", "~> 3.1"
+  spec.add_development_dependency "rspec-rails", "~> 6.0"
   spec.add_development_dependency "sqlite3", "~> 1.6.1"
   spec.add_development_dependency "timecop", "~> 0.9.1"
 


### PR DESCRIPTION
Recreation of the PR from dependabot due to CI changes. Also fixes errors and warnings from RSpec, either pre-existing or due to the dependency bump

Updates the requirements on [rspec-rails](https://github.com/rspec/rspec-rails) to permit the latest version.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/rspec/rspec-rails/blob/main/Changelog.md">rspec-rails's changelog</a>.</em></p>
<blockquote>
<h3>6.0.0</h3>
<p><a href="https://github.com/rspec/rspec-rails/compare/v5.1.2...6.0.0">Full Changelog</a></p>
<p>Enhancements:</p>
<ul>
<li>Support Rails 7</li>
<li>Template tweaks to remove instance variables from generated specs. (Takuma Ishikawa, <a href="https://github-redirect.dependabot.com/rspec/rspec-rails/issues/2599">#2599</a>)</li>
<li>Generators now respects default path configuration option. (<a href="https://github.com/vivekmiyani"><code>@​vivekmiyani</code></a>, <a href="https://github-redirect.dependabot.com/rspec/rspec-rails/issues/2508">#2508</a>)</li>
</ul>
<p>Breaking Changes:</p>
<ul>
<li>Drop support for Rails below 6.1</li>
<li>Drop support for Ruby below 2.5 (following supported versions of Rails 6.1)</li>
<li>Change the order of <code>after_teardown</code> from <code>after</code> to <code>around</code> in system
specs to improve compatibility with extensions and Capybara. (Tim Diggins, <a href="https://github-redirect.dependabot.com/rspec/rspec-rails/issues/2596">#2596</a>)</li>
</ul>
<p>Deprecations:</p>
<ul>
<li>Deprecates integration spec generator (<code>rspec:integration</code>)
which was an alias of request spec generator (<code>rspec:request</code>)
(Luka Lüdicke, <a href="https://github-redirect.dependabot.com/rspec/rspec-rails/issues/2374">#2374</a>)</li>
</ul>
<h3>5.1.2 / 2022-04-24</h3>
<p><a href="https://github.com/rspec/rspec-rails/compare/v5.1.1...v5.1.2">Full Changelog</a></p>
<p>Bug Fixes:</p>
<ul>
<li>Fix controller scaffold templates parameter name.  (Taketo Takashima, <a href="https://github-redirect.dependabot.com/rspec/rspec-rails/issues/2591">#2591</a>)</li>
<li>Include generator specs in the inferred list of specs. (Jason Karns, <a href="https://github-redirect.dependabot.com/rspec/rspec-rails/issues/2597">#2597</a>)</li>
</ul>
<h3>5.1.1 / 2022-03-07</h3>
<p><a href="https://github.com/rspec/rspec-rails/compare/v5.1.0...v5.1.1">Full Changelog</a></p>
<p>Bug Fixes:</p>
<ul>
<li>Properly handle global id serialised arguments in <code>have_enqueued_mail</code>.
(Jon Rowe, <a href="https://github-redirect.dependabot.com/rspec/rspec-rails/issues/2578">#2578</a>)</li>
</ul>
<h3>5.1.0 / 2022-01-26</h3>
<p><a href="https://github.com/rspec/rspec-rails/compare/v5.0.3...v5.1.0">Full Changelog</a></p>
<p>Enhancements:</p>
<ul>
<li>Make the API request scaffold template more consistent and compatible with
Rails 6.1. (Naoto Hamada, <a href="https://github-redirect.dependabot.com/rspec/rspec-rails/issues/2484">#2484</a>)</li>
<li>Change the scaffold <code>rails_helper.rb</code> template to use <code>require_relative</code>.
(Jon Dufresne, <a href="https://github-redirect.dependabot.com/rspec/rspec-rails/issues/2528">#2528</a>)</li>
</ul>
<h3>5.0.3 / 2022-01-26</h3>
<p><a href="https://github.com/rspec/rspec-rails/compare/v5.0.2...v5.0.3">Full Changelog</a></p>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/rspec/rspec-rails/commit/064604441496e0d2de04655c54343adb71884525"><code>0646044</code></a> v6.0.0</li>
<li><a href="https://github.com/rspec/rspec-rails/commit/7cd6f935c085c10599a3d9f472593e6b37f92537"><code>7cd6f93</code></a> s/upload_backups_spec.rb/upload_backups_job_spec.rb/g</li>
<li><a href="https://github.com/rspec/rspec-rails/commit/8016684487b7323a0d0f57e14fd18494287e01f7"><code>8016684</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/rspec/rspec-rails/issues/2587">#2587</a> from rspec/shanecav84/include-tagged-logging</li>
<li><a href="https://github.com/rspec/rspec-rails/commit/0b4d1641d18e2d6353020cfb8d316916f3764448"><code>0b4d164</code></a> Fixed typo</li>
<li><a href="https://github.com/rspec/rspec-rails/commit/396c68f39751c582de7b82bbe4874f4b6b08b11f"><code>396c68f</code></a> This updates Rubocop and uses the .rubocop_rspec_base.yml for consistency</li>
<li><a href="https://github.com/rspec/rspec-rails/commit/efd4e6f5ca77e8458e530a915678d498ea52bee9"><code>efd4e6f</code></a> Respect RSpec default_path for generators <a href="https://github-redirect.dependabot.com/rspec/rspec-rails/issues/2508">#2508</a></li>
<li><a href="https://github.com/rspec/rspec-rails/commit/40192d2953cd5ea7baf3b4820e67fc64a7b17126"><code>40192d2</code></a> Remove legacy</li>
<li><a href="https://github.com/rspec/rspec-rails/commit/126da71cb3bc4265498e802bacf1d964218d84ad"><code>126da71</code></a> Remove version-specific checks for unsupported Rails/Ruby</li>
<li><a href="https://github.com/rspec/rspec-rails/commit/49f7dd59495fa14a61266e4657829e081d1f6058"><code>49f7dd5</code></a> Add integration generator deprecation to changelog</li>
<li><a href="https://github.com/rspec/rspec-rails/commit/f604d5f328e99abfa760e914db4ce41029957c86"><code>f604d5f</code></a> Add only one test for integration generator deprecation</li>
<li>Additional commits viewable in <a href="https://github.com/rspec/rspec-rails/compare/v3.1.0...v6.0.0">compare view</a></li>
</ul>
</details>
<br />