### PR TITLE
Update pg requirement from >= 0.18, <= 1.3 to >= 0.18, <= 1.5

### DIFF
--- a/statesman.gemspec
+++ b/statesman.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "gc_ruboconfig", "~> 3.6.0"
   spec.add_development_dependency "mysql2", ">= 0.4", "< 0.6"
-  spec.add_development_dependency "pg", ">= 0.18", "<= 1.3"
+  spec.add_development_dependency "pg", ">= 0.18", "<= 1.5"
   spec.add_development_dependency "rails", ">= 5.2"
   spec.add_development_dependency "rake", "~> 13.0.0"
   spec.add_development_dependency "rspec", "~> 3.1"


### PR DESCRIPTION
Recreation of dependabot PR due to CI changes not being picked up

Updates the requirements on [pg](https://github.com/ged/ruby-pg) to permit the latest version.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/ged/ruby-pg/blob/master/History.rdoc">pg's changelog</a>.</em></p>
<blockquote>
<p>== v1.4.0 [2022-06-20] Lars Kanis <a href="mailto:lars@greiz-reinsdorf.de">lars@greiz-reinsdorf.de</a></p>
<p>Added:</p>
<ul>
<li>Add PG::Connection#hostaddr, present since PostgreSQL-12. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/453">#453</a></li>
<li>Add PG::Connection.conninfo_parse to wrap PQconninfoParse. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/453">#453</a></li>
</ul>
<p>Bugfixes:</p>
<ul>
<li>Try IPv6 and IPv4 addresses, if DNS resolves to both. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/452">#452</a></li>
<li>Re-add block-call semantics to PG::Connection.new accidently removed in pg-1.3.0. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/454">#454</a></li>
<li>Handle client error after all data consumed in #copy_data for output. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/455">#455</a></li>
<li>Avoid spurious keyword argument warning on Ruby 2.7. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/456">#456</a></li>
<li>Change connection setup to respect connect_timeout parameter. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/459">#459</a></li>
<li>Fix indefinite hang in case of connection error on Windows <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/458">#458</a></li>
<li>Set connection attribute of PG::Error in various places where it was missing. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/461">#461</a></li>
<li>Fix transaction leak on early break/return. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/463">#463</a></li>
<li>Update Windows fat binary gem to OpenSSL-1.1.1o and PostgreSQL-14.4.</li>
</ul>
<p>Enhancements:</p>
<ul>
<li>Don't flush at each put_copy_data call, but flush at get_result. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/462">#462</a></li>
</ul>
<p>== v1.3.5 [2022-03-31] Lars Kanis <a href="mailto:lars@greiz-reinsdorf.de">lars@greiz-reinsdorf.de</a></p>
<p>Bugfixes:</p>
<ul>
<li>Handle PGRES_COMMAND_OK in pgresult_stream_any. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/447">#447</a>
Fixes usage when trying to stream the result of a procedure call that returns no results.</li>
</ul>
<p>Enhancements:</p>
<ul>
<li>Rename BasicTypeRegistry#define_default_types to #register_default_types to use a more consistent terminology.
Keeping define_default_types for compatibility.</li>
<li>BasicTypeRegistry: return self instead of objects by accident.
This allows call chaining.</li>
<li>Add some April fun. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/449">#449</a></li>
</ul>
<p>Documentation:</p>
<ul>
<li>Refine documentation of conn.socket_io and conn.connect_poll</li>
</ul>
<p>== v1.3.4 [2022-03-10] Lars Kanis <a href="mailto:lars@greiz-reinsdorf.de">lars@greiz-reinsdorf.de</a></p>
<p>Bugfixes:</p>
<ul>
<li>Don't leak IO in case of connection errors. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/439">#439</a>
Previously it was kept open until the PG::Connection was garbage collected.</li>
<li>Fix a performance regession in conn.get_result noticed in single row mode. <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/442">#442</a></li>
</ul>
<!-- raw HTML omitted -->
</blockquote>
<p>... (truncated)</p>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/ged/ruby-pg/commit/3c14a309463fbaef569007b134a96e35b022c92e"><code>3c14a30</code></a> Update to postgresql-14.4 and openssl 1.1.1o for Windows binaries</li>
<li><a href="https://github.com/ged/ruby-pg/commit/f5bb30d39785778e3c530b8fc6463fa3ee22da29"><code>f5bb30d</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/464">#464</a> from larskanis/bump-1.4.0</li>
<li><a href="https://github.com/ged/ruby-pg/commit/d58242ee620e1cb9b861d30247daa8cb871a66c1"><code>d58242e</code></a> Bump VERSION to 1.4.0</li>
<li><a href="https://github.com/ged/ruby-pg/commit/443e7cb53e393779ded93cd13bcccb70c38648de"><code>443e7cb</code></a> Add a proxy to enable or disable TCP data flow</li>
<li><a href="https://github.com/ged/ruby-pg/commit/d5e223c1c7e914dfccf9b80de73ed6ec70f081eb"><code>d5e223c</code></a> Don't fail at GC.compact spec on ppc64le</li>
<li><a href="https://github.com/ged/ruby-pg/commit/a6401cd7b0536e314670f1fcb4810b01e0de8add"><code>a6401cd</code></a> Avoid compiler warnings</li>
<li><a href="https://github.com/ged/ruby-pg/commit/e701a9b0f6464e73ecf4730bca7da078d71a3473"><code>e701a9b</code></a> Remove unnecessary variable assignments</li>
<li><a href="https://github.com/ged/ruby-pg/commit/217536e9b86ba7eae52be9022851731bf99f72c7"><code>217536e</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/ged/ruby-pg/issues/463">#463</a> from ejoubaud/fix-transaction-leak</li>
<li><a href="https://github.com/ged/ruby-pg/commit/48bc9b26f5bb76d53cb2abb7c7d55da1db0c58ba"><code>48bc9b2</code></a> Remove useless assignments in test</li>
<li><a href="https://github.com/ged/ruby-pg/commit/df60639ee396a34ffed30483135470011607041f"><code>df60639</code></a> Fix transaction leak on early break/return</li>
<li>Additional commits viewable in <a href="https://github.com/ged/ruby-pg/compare/v0.18.0...v1.4.0">compare view</a></li>
</ul>
</details>
<br />