### PR TITLE
Fixed issue with transitions using STI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,8 @@ RSpec.configure do |config|
       my_namespace_my_active_record_model_transitions
       other_active_record_models
       other_active_record_model_transitions
+      sti_active_record_models
+      sti_active_record_model_transitions
     ]
     tables.each do |table_name|
       sql = "DROP TABLE IF EXISTS #{table_name};"
@@ -70,6 +72,15 @@ RSpec.configure do |config|
     def prepare_other_transitions_table
       CreateOtherActiveRecordModelTransitionMigration.migrate(:up)
       OtherActiveRecordModelTransition.reset_column_information
+    end
+
+    def prepare_sti_model_table
+      CreateStiActiveRecordModelMigration.migrate(:up)
+    end
+
+    def prepare_sti_transitions_table
+      CreateStiActiveRecordModelTransitionMigration.migrate(:up)
+      StiActiveRecordModelTransition.reset_column_information
     end
 
     MyNamespace::MyActiveRecordModelTransition.serialize(:metadata, JSON)


### PR DESCRIPTION
Prior to 7.2.0 the code to unset the `most_recent` column of old transitions when a new transition was created relied on `transitions_for_parent`, which would build the correct query in the case that the transition class was using single table inheritance.

However, after #399, the code no longer uses the parent association to create the query and the current custom query lacks this functionality that existed prior to 7.2.0.

This PR addresses this issue by adding an AND clause to the query to filter by transition type if the transition class contains an inheritance column.