### PR TITLE
Handle the case where the cache is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v10.2.1 3rd April 2023
+
+### Changed
+- Fixed an edge case where `adapter.reset` were failing if the cache is empty
+
 ## v10.2.0 3rd April 2023
 
 ### Changed

--- a/lib/statesman/adapters/active_record.rb
+++ b/lib/statesman/adapters/active_record.rb
@@ -52,7 +52,7 @@ module Statesman
 
         raise
       ensure
-        remove_instance_variable(:@last_transition)
+        reset
       end
 
       def history(force_reload: false)
@@ -76,7 +76,8 @@ module Statesman
       end
 
       def reset
-        remove_instance_variable(:@last_transition)
+        remove_instance_variable(:@last_transition) \
+          if instance_variable_defined?(:@last_transition)
       end
 
       private

--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Statesman
-  VERSION = "10.2.0"
+  VERSION = "10.2.1"
 end

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -388,6 +388,12 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
     end
   end
 
+  describe "#reset" do
+    it "works with empty cache" do
+      expect { model.state_machine.reset }.to_not raise_error
+    end
+  end
+
   it "resets last with #reload" do
     model.save!
     ActiveRecord::Base.transaction do


### PR DESCRIPTION
This was introduced in #505 and caused an error being thrown if one attempts to reset the cache of `last_transition`.

I think this is an edge case because you shouldn't normally do `model.state_machine.reset` unless you know the cache needs invalidation. But this should not throw an error regardless.
