### PR TITLE
fix: Ensuring inheritance

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -39,7 +39,7 @@ module Statesman
         end
 
         def included(base)
-          ensure_inheritance(base)
+          ensure_inheritance(base) unless base.subclasses.none?
 
           query_builder = QueryBuilder.new(base, **@args)
 

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -39,7 +39,7 @@ module Statesman
         end
 
         def included(base)
-          ensure_inheritance(base) unless base.subclasses.none?
+          ensure_inheritance(base) if base.respond_to?(:subclasses) && base.subclasses.any?
 
           query_builder = QueryBuilder.new(base, **@args)
 


### PR DESCRIPTION
The call to `ensure_inheritance` can cause a stack overflow when used in combination with the `enumerize` gem and a standard inherited model (not STI - no type column defined on the table).

https://github.com/gocardless/statesman/pull/373#discussion_r465877454

There's no need to continue with the `ensure_inheritance` when using a standard inherited model; the statesman methods are already available on the subclass.

---

I originally implemented this fix for [v7](https://github.com/skillstream/statesman/commit/8ca396d7368170c68badd357679aed67cd8e9c0d), then cherry-picked for [v9](https://github.com/skillstream/statesman/commit/cb1286052ef9b15a890740180757d5d4f0555644), and now [v10](https://github.com/skillstream/statesman/commit/9c8b9a7ee71443a07856a12343db80c6216cd113). 
