### PR TITLE
Fix reloading state machine caches

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,3 +15,6 @@ Metrics/CyclomaticComplexity:
 
 Metrics/PerceivedComplexity:
   Max: 11
+
+Gemspec/DevelopmentDependencies:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v10.2.3 2nd Aug 2023
+
+### Changed
+- Fixed calls to reloading internal cache is the state_machine was made private / protected
+
 ## v10.2.2 21st April 2023
 
 ### Changed

--- a/lib/generators/statesman/generator_helpers.rb
+++ b/lib/generators/statesman/generator_helpers.rb
@@ -11,7 +11,7 @@ module Statesman
     end
 
     def migration_class_name
-      klass.gsub(/::/, "").pluralize
+      klass.gsub("::", "").pluralize
     end
 
     def next_migration_number

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -53,7 +53,7 @@ module Statesman
           define_method(:reload) do |*a|
             instance = super(*a)
             if instance.respond_to?(:state_machine, true)
-              instance.state_machine.reset
+              instance.send(:state_machine).reset
             end
             instance
           end

--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Statesman
-  VERSION = "10.2.2"
+  VERSION = "10.2.3"
 end


### PR DESCRIPTION
Passing `true` to `respond_to?` means that private and protected methods are considered, in the subsequent call we make a standard call to the method which will fail if the `state_machine` has been made private.

See https://github.com/gocardless/payments-service/pull/42438 for a stuck upgrade