### PR TITLE
Silence the deprecation warnings introduced in Rails 7.1

### DIFF
--- a/lib/statesman/adapters/active_record_transition.rb
+++ b/lib/statesman/adapters/active_record_transition.rb
@@ -10,7 +10,7 @@ module Statesman
       extend ActiveSupport::Concern
 
       included do
-        serialize :metadata, JSON
+        serialize :metadata, coder: JSON
 
         class_attribute :updated_timestamp_column
         self.updated_timestamp_column = DEFAULT_UPDATED_TIMESTAMP_COLUMN

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,6 +83,6 @@ RSpec.configure do |config|
       StiActiveRecordModelTransition.reset_column_information
     end
 
-    MyNamespace::MyActiveRecordModelTransition.serialize(:metadata, JSON)
+    MyNamespace::MyActiveRecordModelTransition.serialize(:metadata, coder: JSON)
   end
 end

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -10,7 +10,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
     prepare_model_table
     prepare_transitions_table
 
-    MyActiveRecordModelTransition.serialize(:metadata, JSON)
+    MyActiveRecordModelTransition.serialize(:metadata, coder: JSON)
 
     prepare_sti_model_table
     prepare_sti_transitions_table
@@ -468,7 +468,7 @@ describe Statesman::Adapters::ActiveRecord, active_record: true do
     end
 
     before do
-      MyNamespace::MyActiveRecordModelTransition.serialize(:metadata, JSON)
+      MyNamespace::MyActiveRecordModelTransition.serialize(:metadata, coder: JSON)
     end
 
     let(:observer) { double(Statesman::Machine, execute: nil) }

--- a/spec/statesman/adapters/active_record_transition_spec.rb
+++ b/spec/statesman/adapters/active_record_transition_spec.rb
@@ -8,7 +8,7 @@ describe Statesman::Adapters::ActiveRecordTransition do
 
   describe "including behaviour" do
     it "calls Class.serialize" do
-      expect(transition_class).to receive(:serialize).with(:metadata, JSON).once
+      expect(transition_class).to receive(:serialize).with(:metadata, coder: JSON).once
       transition_class.send(:include, described_class)
     end
   end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -24,7 +24,7 @@ class MyActiveRecordModelTransition < ActiveRecord::Base
   include Statesman::Adapters::ActiveRecordTransition
 
   belongs_to :my_active_record_model
-  serialize :metadata, JSON
+  serialize :metadata, coder: JSON
 end
 
 class MyActiveRecordModel < ActiveRecord::Base
@@ -51,7 +51,7 @@ class MyActiveRecordModelTransitionWithoutInclude < ActiveRecord::Base
   self.table_name = "my_active_record_model_transitions"
 
   belongs_to :my_active_record_model
-  serialize :metadata, JSON
+  serialize :metadata, coder: JSON
 end
 
 class CreateMyActiveRecordModelMigration < MIGRATION_CLASS
@@ -129,7 +129,7 @@ class OtherActiveRecordModelTransition < ActiveRecord::Base
   include Statesman::Adapters::ActiveRecordTransition
 
   belongs_to :other_active_record_model
-  serialize :metadata, JSON
+  serialize :metadata, coder: JSON
 end
 
 class CreateOtherActiveRecordModelMigration < MIGRATION_CLASS
@@ -221,7 +221,7 @@ module MyNamespace
 
     belongs_to :my_active_record_model,
                class_name: "MyNamespace::MyActiveRecordModel"
-    serialize :metadata, JSON
+    serialize :metadata, coder: JSON
 
     def self.table_name_prefix
       "my_namespace_"
@@ -310,7 +310,7 @@ class StiActiveRecordModelTransition < ActiveRecord::Base
   include Statesman::Adapters::ActiveRecordTransition
 
   belongs_to :sti_active_record_model
-  serialize :metadata, JSON
+  serialize :metadata, coder: JSON
 end
 
 class StiAActiveRecordModelTransition < StiActiveRecordModelTransition


### PR DESCRIPTION
> DEPRECATION WARNING: Passing the coder as positional argument is deprecated and will be removed in Rails 7.2.
>
> Please pass the coder as a keyword argument:
>
>   serialize :metadata, coder: JSON