### PR TITLE
Add multi-database support to Statesman.

### DIFF
--- a/lib/generators/statesman/generator_helpers.rb
+++ b/lib/generators/statesman/generator_helpers.rb
@@ -52,7 +52,7 @@ module Statesman
     end
 
     def database_supports_partial_indexes?
-      Statesman::Adapters::ActiveRecord.database_supports_partial_indexes?
+      Statesman::Adapters::ActiveRecord.database_supports_partial_indexes?(klass.constantize)
     end
 
     def metadata_default_value

--- a/lib/statesman.rb
+++ b/lib/statesman.rb
@@ -34,10 +34,8 @@ module Statesman
     @storage_adapter || Adapters::Memory
   end
 
-  def self.mysql_gaplock_protection?
-    return @mysql_gaplock_protection unless @mysql_gaplock_protection.nil?
-
-    @mysql_gaplock_protection = config.mysql_gaplock_protection?
+  def self.mysql_gaplock_protection?(connection)
+    config.mysql_gaplock_protection?(connection)
   end
 
   def self.config

--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -153,7 +153,7 @@ module Statesman
         end
 
         def db_true
-          ::ActiveRecord::Base.connection.quote(true)
+          model.connection.quote(true)
         end
       end
     end

--- a/lib/statesman/config.rb
+++ b/lib/statesman/config.rb
@@ -15,17 +15,10 @@ module Statesman
       @adapter_class = adapter_class
     end
 
-    def mysql_gaplock_protection?
-      return @mysql_gaplock_protection unless @mysql_gaplock_protection.nil?
-
+    def mysql_gaplock_protection?(connection)
       # If our adapter class suggests we're using mysql, enable gaplock protection by
       # default.
-      enable_mysql_gaplock_protection if mysql_adapter?(adapter_class)
-      @mysql_gaplock_protection
-    end
-
-    def enable_mysql_gaplock_protection
-      @mysql_gaplock_protection = true
+      mysql_adapter?(connection)
     end
 
     private
@@ -34,7 +27,7 @@ module Statesman
       adapter_name = adapter_name(adapter_class)
       return false unless adapter_name
 
-      adapter_name.start_with?("mysql")
+      adapter_name.downcase.start_with?("mysql")
     end
 
     def adapter_name(adapter_class)

--- a/lib/tasks/statesman.rake
+++ b/lib/tasks/statesman.rake
@@ -21,8 +21,8 @@ namespace :statesman do
     batch_size = 500
 
     parent_class.find_in_batches(batch_size: batch_size) do |models|
-      ActiveRecord::Base.transaction(requires_new: true) do
-        if Statesman::Adapters::ActiveRecord.database_supports_partial_indexes?
+      transition_class.transaction(requires_new: true) do
+        if Statesman::Adapters::ActiveRecord.database_supports_partial_indexes?(transition_class)
           # Set all transitions' most_recent to FALSE
           transition_class.where(parent_fk => models.map(&:id)).
             update_all(most_recent: false, updated_at: updated_at)

--- a/spec/generators/statesman/active_record_transition_generator_spec.rb
+++ b/spec/generators/statesman/active_record_transition_generator_spec.rb
@@ -4,6 +4,13 @@ require "support/generators_shared_examples"
 require "generators/statesman/active_record_transition_generator"
 
 describe Statesman::ActiveRecordTransitionGenerator, type: :generator do
+  before do
+    stub_const("Bacon", Class.new(ActiveRecord::Base))
+    stub_const("BaconTransition", Class.new(ActiveRecord::Base))
+    stub_const("Yummy::Bacon", Class.new(ActiveRecord::Base))
+    stub_const("Yummy::BaconTransition", Class.new(ActiveRecord::Base))
+  end
+
   it_behaves_like "a generator" do
     let(:migration_name) { "db/migrate/create_bacon_transitions.rb" }
   end

--- a/spec/generators/statesman/migration_generator_spec.rb
+++ b/spec/generators/statesman/migration_generator_spec.rb
@@ -4,6 +4,11 @@ require "support/generators_shared_examples"
 require "generators/statesman/migration_generator"
 
 describe Statesman::MigrationGenerator, type: :generator do
+  before do
+    stub_const("Yummy::Bacon", Class.new(ActiveRecord::Base))
+    stub_const("Yummy::BaconTransition", Class.new(ActiveRecord::Base))
+  end
+
   it_behaves_like "a generator" do
     let(:migration_name) { "db/migrate/add_statesman_to_bacon_transitions.rb" }
   end

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -9,8 +9,6 @@ describe Statesman::Adapters::ActiveRecord, :active_record do
     prepare_model_table
     prepare_transitions_table
 
-    # MyActiveRecordModelTransition.serialize(:metadata, JSON)
-
     prepare_sti_model_table
     prepare_sti_transitions_table
 
@@ -25,8 +23,10 @@ describe Statesman::Adapters::ActiveRecord, :active_record do
 
   after { Statesman.configure { storage_adapter(Statesman::Adapters::Memory) } }
 
+  let(:model_class) { MyActiveRecordModel }
+  let(:transition_class) { MyActiveRecordModelTransition }
   let(:observer) { double(Statesman::Machine, execute: nil) }
-  let(:model) { MyActiveRecordModel.create(current_state: :pending) }
+  let(:model) { model_class.create(current_state: :pending) }
 
   it_behaves_like "an adapter", described_class, MyActiveRecordModelTransition
 
@@ -35,8 +35,8 @@ describe Statesman::Adapters::ActiveRecord, :active_record do
       before do
         metadata_column = double
         allow(metadata_column).to receive_messages(sql_type: "")
-        allow(MyActiveRecordModelTransition).to receive_messages(columns_hash:
-                                           { "metadata" => metadata_column })
+        allow(MyActiveRecordModelTransition).
+          to receive_messages(columns_hash: { "metadata" => metadata_column })
         expect(MyActiveRecordModelTransition).
           to receive(:type_for_attribute).with("metadata").
           and_return(ActiveRecord::Type::Value.new)
@@ -104,12 +104,14 @@ describe Statesman::Adapters::ActiveRecord, :active_record do
   describe "#create" do
     subject(:transition) { create }
 
-    let!(:adapter) do
-      described_class.new(MyActiveRecordModelTransition, model, observer)
-    end
+    let!(:adapter) { described_class.new(transition_class, model, observer) }
     let(:from) { :x }
     let(:to) { :y }
     let(:create) { adapter.create(from, to) }
+
+    it "only connects to the primary database" do
+      expect { create }.to exactly_query_databases({ primary: [:writing] })
+    end
 
     context "when there is a race" do
       it "raises a TransitionConflictError" do
@@ -118,7 +120,8 @@ describe Statesman::Adapters::ActiveRecord, :active_record do
         adapter.last
         adapter2.create(:y, :z)
         expect { adapter.create(:y, :z) }.
-          to raise_exception(Statesman::TransitionConflictError)
+          to raise_exception(Statesman::TransitionConflictError).
+          and exactly_query_databases({ primary: [:writing] })
       end
 
       it "does not pollute the state when the transition fails" do
@@ -342,12 +345,34 @@ describe Statesman::Adapters::ActiveRecord, :active_record do
         end
       end
     end
+
+    context "when using the secondary database" do
+      let(:model_class) { SecondaryActiveRecordModel }
+      let(:transition_class) { SecondaryActiveRecordModelTransition }
+
+      it "doesn't connect to the primary database" do
+        expect { create }.to exactly_query_databases({ secondary: [:writing] })
+        expect(adapter.last.to_state).to eq("y")
+      end
+
+      context "when there is a race" do
+        it "raises a TransitionConflictError and uses the correct database" do
+          adapter2 = adapter.dup
+          adapter2.create(:x, :y)
+          adapter.last
+          adapter2.create(:y, :z)
+
+          expect { adapter.create(:y, :z) }.
+            to raise_exception(Statesman::TransitionConflictError).
+            and exactly_query_databases({ secondary: [:writing] })
+        end
+      end
+    end
   end
 
   describe "#last" do
-    let(:adapter) do
-      described_class.new(MyActiveRecordModelTransition, model, observer)
-    end
+    let(:transition_class) { MyActiveRecordModelTransition }
+    let(:adapter) { described_class.new(transition_class, model, observer) }
 
     context "with a previously looked up transition" do
       before { adapter.create(:x, :y) }
@@ -364,7 +389,18 @@ describe Statesman::Adapters::ActiveRecord, :active_record do
         before { adapter.create(:y, :z, []) }
 
         it "retrieves the new transition from the database" do
+          expect { adapter.last.to_state }.to exactly_query_databases({ primary: [:writing] })
           expect(adapter.last.to_state).to eq("z")
+        end
+
+        context "when using the secondary database" do
+          let(:model_class) { SecondaryActiveRecordModel }
+          let(:transition_class) { SecondaryActiveRecordModelTransition }
+
+          it "retrieves the new transition from the database" do
+            expect { adapter.last.to_state }.to exactly_query_databases({ secondary: [:writing] })
+            expect(adapter.last.to_state).to eq("z")
+          end
         end
       end
 

--- a/spec/support/exactly_query_databases.rb
+++ b/spec/support/exactly_query_databases.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# `expected_dbs` should be a Hash of the form:
+# {
+#   primary: [:writing, :reading],
+#   replica: [:reading],
+# }
+RSpec::Matchers.define :exactly_query_databases do |expected_dbs|
+  match do |block|
+    @expected_dbs = expected_dbs.transform_values(&:to_set).with_indifferent_access
+    @actual_dbs = Hash.new { |h, k| h[k] = Set.new }.with_indifferent_access
+
+    ActiveSupport::Notifications.
+      subscribe("sql.active_record") do |_name, _start, _finish, _id, payload|
+      pool = payload.fetch(:connection).pool
+
+      next if pool.is_a?(ActiveRecord::ConnectionAdapters::NullPool)
+
+      name = pool.db_config.name
+      role = pool.role
+
+      @actual_dbs[name] << role
+    end
+
+    block.call
+
+    @actual_dbs == @expected_dbs
+  end
+
+  failure_message do |_block|
+    "expected to query exactly #{@expected_dbs}, but queried #{@actual_dbs}"
+  end
+
+  supports_block_expectations
+end


### PR DESCRIPTION
Statesman currently relies heavily on `ActiveRecord::Base`, either explicitly or implicitly, when querying database connections. This doesn't play well when we have models or transitions which live on a different database, since it forces us to open a query to the primary connection pool.

This is a series of changes to allow Statesman to use the context it has available for the model or transition class, and make use of the appropriate connection.