### PR TITLE
Add .rspec file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,9 +55,6 @@ Gemfile.lock
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
 
-# Project-specific ignores
-.rspec
-
 # VSCode
 .vscode
 

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/generators/statesman/active_record_transition_generator_spec.rb
+++ b/spec/generators/statesman/active_record_transition_generator_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "support/generators_shared_examples"
 require "generators/statesman/active_record_transition_generator"
 

--- a/spec/generators/statesman/migration_generator_spec.rb
+++ b/spec/generators/statesman/migration_generator_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "support/generators_shared_examples"
 require "generators/statesman/migration_generator"
 

--- a/spec/statesman/adapters/active_record_queries_spec.rb
+++ b/spec/statesman/adapters/active_record_queries_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe Statesman::Adapters::ActiveRecordQueries, :active_record do
   def configure_old(klass, transition_class)
     klass.define_singleton_method(:transition_class) { transition_class }

--- a/spec/statesman/adapters/active_record_spec.rb
+++ b/spec/statesman/adapters/active_record_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "timecop"
 require "statesman/adapters/shared_examples"
 require "statesman/exceptions"

--- a/spec/statesman/adapters/active_record_transition_spec.rb
+++ b/spec/statesman/adapters/active_record_transition_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "json"
 
 describe Statesman::Adapters::ActiveRecordTransition do

--- a/spec/statesman/adapters/memory_spec.rb
+++ b/spec/statesman/adapters/memory_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "statesman/adapters/shared_examples"
 require "statesman/adapters/memory_transition"
 

--- a/spec/statesman/adapters/memory_transition_spec.rb
+++ b/spec/statesman/adapters/memory_transition_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
 require "statesman/adapters/memory_transition"
 
 describe Statesman::Adapters::MemoryTransition do

--- a/spec/statesman/adapters/shared_examples.rb
+++ b/spec/statesman/adapters/shared_examples.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 # All adpators must define seven methods:
 #   initialize:       Accepts a transition class, parent model and state_attr.
 #   transition_class: Returns the transition class object passed to initialize.

--- a/spec/statesman/adapters/type_safe_active_record_queries_spec.rb
+++ b/spec/statesman/adapters/type_safe_active_record_queries_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe Statesman::Adapters::TypeSafeActiveRecordQueries, :active_record do
   def configure(klass, transition_class)
     klass.send(:extend, described_class)

--- a/spec/statesman/callback_spec.rb
+++ b/spec/statesman/callback_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe Statesman::Callback do
   let(:cb_lambda) { -> {} }
   let(:callback) do

--- a/spec/statesman/config_spec.rb
+++ b/spec/statesman/config_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe Statesman::Config do
   let(:instance) { described_class.new }
 

--- a/spec/statesman/exceptions_spec.rb
+++ b/spec/statesman/exceptions_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe "Exceptions" do
   describe "InvalidStateError" do
     subject(:error) { Statesman::InvalidStateError.new }

--- a/spec/statesman/guard_spec.rb
+++ b/spec/statesman/guard_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe Statesman::Guard do
   let(:callback) { -> {} }
   let(:guard) { described_class.new(from: nil, to: nil, callback: callback) }

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe Statesman::Machine do
   let(:machine) { Class.new { include Statesman::Machine } }
   let(:my_model) { Class.new { attr_accessor :current_state }.new }

--- a/spec/statesman/utils_spec.rb
+++ b/spec/statesman/utils_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "spec_helper"
-
 describe Statesman::Utils do
   describe ".rails_major_version" do
     subject { described_class.rails_major_version }


### PR DESCRIPTION
This allows us to remove `require "spec_helper"` from spec files.