### PR TITLE
Bump version to 12.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v12.0.0 30th November 2023
+
+### Changed
+- Added multi-database support [#522](https://github.com/gocardless/statesman/pull/522)
+  - This now uses the correct ActiveRecord connection for the model or transition in a multi-database environment
+
 ## v11.0.0 3rd November 2023
 
 ### Changed

--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Statesman
-  VERSION = "11.0.0"
+  VERSION = "12.0.0"
 end


### PR DESCRIPTION
- Added multi-database support [#522](https://github.com/gocardless/statesman/pull/522)
  - This now uses the correct ActiveRecord connection for the model or transition in a multi-database environment
