### PR TITLE
Enable gaplock protection when using trilogy mysql adapter

### DIFF
--- a/lib/statesman/config.rb
+++ b/lib/statesman/config.rb
@@ -27,7 +27,7 @@ module Statesman
       adapter_name = adapter_name(adapter_class)
       return false unless adapter_name
 
-      adapter_name.downcase.start_with?("mysql")
+      adapter_name.downcase.start_with?("mysql", "trilogy")
     end
 
     def adapter_name(adapter_class)


### PR DESCRIPTION
In https://github.com/gocardless/statesman/pull/522 the ability to enable gaplock protection manually was removed, likely assuming there was no need for this since it's enabled by default when using an adapter that is named `mysql*`, however we use
https://github.com/trilogy-libraries/trilogy which has been gaining some traction in the community and this change now leaves us without a way to enable the functionality.

I think it makes most sense to enable the functionality by default when using this new adapter as well, and keep config requirements minimal, so I added a little check for that adapter name as well.