### PR TITLE
Fix autoloading the VERSION constant

### DIFF
--- a/lib/statesman.rb
+++ b/lib/statesman.rb
@@ -6,7 +6,7 @@ module Statesman
   autoload :Callback,   "statesman/callback"
   autoload :Guard,      "statesman/guard"
   autoload :Utils,      "statesman/utils"
-  autoload :Version,    "statesman/version"
+  autoload :VERSION,    "statesman/version"
   module Adapters
     autoload :Memory,       "statesman/adapters/memory"
     autoload :ActiveRecord, "statesman/adapters/active_record"


### PR DESCRIPTION
While waiting for Statesman to support gap lock protection for Trilogy by default (#528) , I wanted to add a conditional monkeypatch to my Rails app based on the version of Statesman loaded. However, trying to reference `Statesman::VERSION` leads to an error:

```
$ irb
irb(main):001> require "statesman"
=> true
irb(main):002> Statesman::VERSION
(irb):2:in `<main>': uninitialized constant Statesman::VERSION (NameError)
Did you mean?  Statesman::Version
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.11.0/exe/irb:9:in `<top (required)>'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/bin/irb:25:in `load'
        from /home/hartley/.cache/asdf/installs/ruby/3.2.2/bin/irb:25:in `<main>'
```

This commit fixes the issue by changing the autoload for the `version.rb` file to point to `VERSION` instead of `Version` (which does not exist).