### PR TITLE
Allow the state_machine method to return nil.

### DIFF
--- a/lib/statesman/adapters/active_record_queries.rb
+++ b/lib/statesman/adapters/active_record_queries.rb
@@ -53,7 +53,7 @@ module Statesman
           define_method(:reload) do |*a|
             instance = super(*a)
             if instance.respond_to?(:state_machine, true)
-              instance.send(:state_machine).reset
+              instance.send(:state_machine)&.reset
             end
             instance
           end


### PR DESCRIPTION
In our product we have a model that has an optional state machine. The `state_machine` method returns nil for instances where no state_machine is appropriate / the state machine functionality is not relevant. 

This method was causing an exception when the instance was reloaded. It's fixed with this safe navigation operator. 