### PR TITLE
Fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Calling `active_record.reload` resets the adapater's internal cache
+- Calling `active_record.reload` resets the adapter's internal cache
 
 ## v10.2.1 3rd April 2023
 
@@ -450,7 +450,7 @@ No changes from v1.0.0.beta2
 
 ### Fixed
 
-- `ActiveRecordModel.in_state` and `ActiveRecordModel.not_in_state` now handle inital states correctly (patch by [@isaacseymour](https://github.com/isaacseymour))
+- `ActiveRecordModel.in_state` and `ActiveRecordModel.not_in_state` now handle initial states correctly (patch by [@isaacseymour](https://github.com/isaacseymour))
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ end
 By default Statesman does not record a transition to the initial state of the state machine.
 
 You can configure Statesman to record a transition to the initial state, this will allow you to:
-- Keep an accurate record of the intial state even if configuration changes
+- Keep an accurate record of the initial state even if configuration changes
 - Keep a record of how long the state machine spent in the initial state
 - Utilise a transition hook for the transition to the initial state
 
@@ -511,7 +511,7 @@ Raised if:
 ### Runtime errors
 
 These errors are raised by `transition_to!`. Using `transition_to` will
-supress `GuardFailedError` and `TransitionFailedError` and return `false` instead.
+suppress `GuardFailedError` and `TransitionFailedError` and return `false` instead.
 
 #### GuardFailedError
 

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -995,7 +995,7 @@ describe Statesman::Machine do
     let(:instance) { machine.new(my_model) }
     let(:metadata) { { some: :metadata } }
 
-    context "when it is succesful" do
+    context "when it is successful" do
       before do
         expect(instance).to receive(:transition_to!).once.
           with(:some_state, metadata).and_return(:some_state)


### PR DESCRIPTION
Found via `typos --format brief`