### PR TITLE
Remove reference to `statesman-events` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,22 +613,6 @@ Given a field `foo` that was stored in the metadata, you can access it like so:
 model_instance.state_machine.last_transition.metadata["foo"]
 ```
 
-### Events
-
-Used to using a state machine with "events"? Support for events is provided by
-the [statesman-events](https://github.com/gocardless/statesman-events) gem. Once
-that's included in your Gemfile you can include event functionality in your
-state machine as follows:
-
-```ruby
-class OrderStateMachine
-  include Statesman::Machine
-  include Statesman::Events
-
-  ...
-end
-```
-
 ### Deleting records
 
 If you need to delete the Parent model regularly you will need to change


### PR DESCRIPTION
If the `statesman-events` repo is not longer maintained, it should not be referenced from this documentation.