### PR TITLE
Fixup transition model generator for namespaced models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ Gemfile.lock
 
 # JetBrains
 .idea
+spec/support/generator-tmp/

--- a/lib/generators/statesman/active_record_transition_generator.rb
+++ b/lib/generators/statesman/active_record_transition_generator.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require "rails/generators"
+require "rails/generators/active_record"
 require "generators/statesman/generator_helpers"
 
 module Statesman
   class ActiveRecordTransitionGenerator < Rails::Generators::Base
     include Statesman::GeneratorHelpers
+    include ActiveRecord::Generators::Migration
 
     desc "Create an ActiveRecord-based transition model" \
          "with the required attributes"
@@ -16,14 +18,11 @@ module Statesman
     source_root File.expand_path("templates", __dir__)
 
     def create_model_file
-      template("create_migration.rb.erb", migration_file_name)
       template("active_record_transition_model.rb.erb", model_file_name)
     end
 
-    private
-
-    def migration_file_name
-      "db/migrate/#{next_migration_number}_create_#{table_name}.rb"
+    def create_migration_file
+      migration_template("create_migration.rb.erb", File.join(db_migrate_path, "create_#{table_name}.rb"))
     end
   end
 end

--- a/lib/generators/statesman/generator_helpers.rb
+++ b/lib/generators/statesman/generator_helpers.rb
@@ -10,36 +10,44 @@ module Statesman
       "app/models/#{klass.underscore}.rb"
     end
 
-    def migration_class_name
-      klass.gsub("::", "").pluralize
-    end
-
-    def next_migration_number
-      Time.now.utc.strftime("%Y%m%d%H%M%S")
-    end
-
     def parent_name
-      parent.demodulize.underscore
+      parent.underscore.split("/").join("_")
     end
 
     def parent_table_name
-      parent.demodulize.underscore.pluralize
+      parent.underscore.split("/").join("_").tableize
     end
 
     def parent_id
       parent_name + "_id"
     end
 
-    def table_name
+    def association_name
       klass.demodulize.underscore.pluralize
+    end
+
+    def table_name
+      klass.underscore.split("/").join("_").tableize
+    end
+
+    def metadata_column_type
+      if ActiveRecord::Base.connection.supports_json?
+        postgres? ? :jsonb : :json
+      else
+        :text
+      end
     end
 
     def index_name(index_id)
       "index_#{table_name}_#{index_id}"
     end
 
+    def postgres?
+      configuration.adapter.try(:match, /postgres/)
+    end
+
     def mysql?
-      configuration.try(:[], "adapter").try(:match, /mysql/)
+      configuration.adapter.try(:match, /mysql/)
     end
 
     # [] is deprecated and will be removed in 6.2

--- a/lib/generators/statesman/generator_helpers.rb
+++ b/lib/generators/statesman/generator_helpers.rb
@@ -60,7 +60,7 @@ module Statesman
     end
 
     def database_supports_partial_indexes?
-      Statesman::Adapters::ActiveRecord.database_supports_partial_indexes?(klass.constantize)
+      Statesman::Adapters::ActiveRecord.database_supports_partial_indexes?(parent.constantize)
     end
 
     def metadata_default_value

--- a/lib/generators/statesman/generator_helpers.rb
+++ b/lib/generators/statesman/generator_helpers.rb
@@ -64,7 +64,13 @@ module Statesman
     end
 
     def metadata_default_value
-      Utils.rails_5_or_higher? ? "{}" : "{}".inspect
+      Utils.rails_5_or_higher? ? "{}" : "'{}'"
+    end
+
+    def metadata_column_config
+      return if mysql?
+
+      ", default: #{metadata_default_value}"
     end
   end
 end

--- a/lib/generators/statesman/migration_generator.rb
+++ b/lib/generators/statesman/migration_generator.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require "rails/generators"
+require "rails/generators/active_record"
 require "generators/statesman/generator_helpers"
 
 # Add statesman attributes to a pre-existing transition class
 module Statesman
   class MigrationGenerator < Rails::Generators::Base
     include Statesman::GeneratorHelpers
+    include ActiveRecord::Generators::Migration
 
     desc "Add the required Statesman attributes to your transition model"
 
@@ -15,14 +17,8 @@ module Statesman
 
     source_root File.expand_path("templates", __dir__)
 
-    def create_model_file
-      template("update_migration.rb.erb", file_name)
-    end
-
-    private
-
-    def file_name
-      "db/migrate/#{next_migration_number}_add_statesman_to_#{table_name}.rb"
+    def create_migration_file
+      migration_template("update_migration.rb.erb", File.join(db_migrate_path, "add_statesman_to_#{table_name}.rb"))
     end
   end
 end

--- a/lib/generators/statesman/templates/active_record_transition_model.rb.erb
+++ b/lib/generators/statesman/templates/active_record_transition_model.rb.erb
@@ -12,14 +12,14 @@ class <%= klass %> < <%= Statesman::Utils.rails_5_or_higher? ? 'ApplicationRecor
   attr_accessible :from_state, :to_state, :metadata, :sort_key
 
 <%- end -%>
-  belongs_to :<%= parent_name %><%= class_name_option %>, inverse_of: :<%= table_name %>
+  belongs_to :<%= parent_name %><%= class_name_option %>, inverse_of: :<%= association_name %>
 
   after_destroy :update_most_recent, if: :most_recent?
 
   private
 
   def update_most_recent
-    last_transition = <%= parent_name %>.<%= table_name %>.order(:sort_key).last
+    last_transition = <%= parent_name %>.<%= association_name %>.order(:sort_key).last
     return unless last_transition.present?
     last_transition.update_column(:most_recent, true)
   end

--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -1,9 +1,9 @@
-class Create<%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveRecord::Migration.current_version}]" if Statesman::Utils.rails_5_or_higher? %>
+class <%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveRecord::Migration.current_version}]" if Statesman::Utils.rails_5_or_higher? %>
   def change
     create_table :<%= table_name %> do |t|
       t.string :from_state, null: false
       t.string :to_state, null: false
-      t.text :metadata<%= ", default: #{metadata_default_value}" unless mysql? %>
+      t.<%= metadata_column_type %> :metadata<%= ", default: #{metadata_default_value}" unless mysql? %>
       t.integer :sort_key, null: false
       t.integer :<%= parent_id %>, null: false
       t.boolean :most_recent<%= ", null: false" if database_supports_partial_indexes? %>

--- a/lib/generators/statesman/templates/create_migration.rb.erb
+++ b/lib/generators/statesman/templates/create_migration.rb.erb
@@ -3,7 +3,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveRecord:
     create_table :<%= table_name %> do |t|
       t.string :from_state, null: false
       t.string :to_state, null: false
-      t.<%= metadata_column_type %> :metadata<%= ", default: #{metadata_default_value}" unless mysql? %>
+      t.<%= metadata_column_type %> :metadata<%= metadata_column_config %>
       t.integer :sort_key, null: false
       t.integer :<%= parent_id %>, null: false
       t.boolean :most_recent<%= ", null: false" if database_supports_partial_indexes? %>

--- a/lib/generators/statesman/templates/update_migration.rb.erb
+++ b/lib/generators/statesman/templates/update_migration.rb.erb
@@ -2,7 +2,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveRecord:
   def change
     add_column :<%= table_name %>, :from_state, :string, null: false
     add_column :<%= table_name %>, :to_state, :string, null: false
-    add_column :<%= table_name %>, :metadata, :<%= metadata_column_type %><%= ", default: #{metadata_default_value}" unless mysql? %>
+    add_column :<%= table_name %>, :metadata, :<%= metadata_column_type %><%= metadata_column_config%>
     add_column :<%= table_name %>, :sort_key, :integer, null: false
     add_column :<%= table_name %>, :<%= parent_id %>, :integer, null: false
     add_column :<%= table_name %>, :most_recent, null: false

--- a/lib/generators/statesman/templates/update_migration.rb.erb
+++ b/lib/generators/statesman/templates/update_migration.rb.erb
@@ -1,8 +1,8 @@
-class AddStatesmanTo<%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveRecord::Migration.current_version}]" if Statesman::Utils.rails_5_or_higher? %>
+class <%= migration_class_name %> < ActiveRecord::Migration<%= "[#{ActiveRecord::Migration.current_version}]" if Statesman::Utils.rails_5_or_higher? %>
   def change
     add_column :<%= table_name %>, :from_state, :string, null: false
     add_column :<%= table_name %>, :to_state, :string, null: false
-    add_column :<%= table_name %>, :metadata, :text<%= ", default: #{metadata_default_value}" unless mysql? %>
+    add_column :<%= table_name %>, :metadata, :<%= metadata_column_type %><%= ", default: #{metadata_default_value}" unless mysql? %>
     add_column :<%= table_name %>, :sort_key, :integer, null: false
     add_column :<%= table_name %>, :<%= parent_id %>, :integer, null: false
     add_column :<%= table_name %>, :most_recent, null: false

--- a/spec/generators/statesman/migration_generator_spec.rb
+++ b/spec/generators/statesman/migration_generator_spec.rb
@@ -2,6 +2,7 @@
 
 require "support/generators_shared_examples"
 require "generators/statesman/migration_generator"
+require "rails/generators/testing/behavior"
 
 describe Statesman::MigrationGenerator, type: :generator do
   before do
@@ -9,40 +10,46 @@ describe Statesman::MigrationGenerator, type: :generator do
     stub_const("Yummy::BaconTransition", Class.new(ActiveRecord::Base))
   end
 
+  around { |e| Timecop.freeze(Time.parse("2025-01-01 00:00:00"), &e) }
+
   it_behaves_like "a generator" do
-    let(:migration_name) { "db/migrate/add_statesman_to_bacon_transitions.rb" }
+    let(:migration_name) { "db/migrate/20250101000000_add_statesman_to_yummy_bacon_transitions.rb" }
   end
 
   describe "the model contains the correct words" do
     subject(:migration) do
       file(
-        "db/migrate/#{migration_number}_add_statesman_to_bacon_transitions.rb",
+        "db/migrate/20250101000000_add_statesman_to_yummy_bacon_transitions.rb",
       )
     end
 
-    let(:migration_number) { "5678309" }
-
-    let(:mock_time) do
-      double("Time", utc: double("UTCTime", strftime: migration_number))
-    end
-
     before do
-      allow(Time).to receive(:now).and_return(mock_time)
       run_generator %w[Yummy::Bacon Yummy::BaconTransition]
     end
 
-    it { is_expected.to contain(/:bacon_transition/) }
-    it { is_expected.to_not contain(%r{:yummy/bacon}) }
+    it { is_expected.to contain(/:yummy_bacon_transition/) }
     it { is_expected.to contain(/null: false/) }
 
     it "names the sorting index appropriately" do
       expect(migration).
-        to contain("name: \"index_bacon_transitions_parent_sort\"")
+        to contain("name: \"index_yummy_bacon_transitions_parent_sort\"")
     end
 
     it "names the most_recent index appropriately" do
       expect(migration).
-        to contain("name: \"index_bacon_transitions_parent_most_recent\"")
+        to contain("name: \"index_yummy_bacon_transitions_parent_most_recent\"")
+    end
+
+    it "uses the right column type for Postgres", if: postgres? do
+      expect(migration).to contain(":metadata, :jsonb")
+    end
+
+    it "uses the right column type for MySQL", if: mysql? do
+      expect(migration).to contain(":metadata, :json")
+    end
+
+    it "uses the right column type for SQLite", if: sqlite? do
+      expect(migration).to contain(":metadata, :json")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,7 @@ require "rspec/rails"
 require "support/exactly_query_databases"
 require "rspec/its"
 require "pry"
+require "timecop"
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -414,3 +414,16 @@ class CreateStiActiveRecordModelTransitionMigration < MIGRATION_CLASS
     end
   end
 end
+
+def postgres?
+  ActiveRecord::Base.connection.adapter_name.match?(/postgres/i)
+end
+
+def mysql?
+  ActiveRecord::Base.connection.adapter_name.match?(/mysql/i) ||
+    ActiveRecord::Base.connection.adapter_name.match?(/trilogy/i)
+end
+
+def sqlite?
+  ActiveRecord::Base.connection.adapter_name.match?(/sqlite/i)
+end

--- a/spec/support/generators_shared_examples.rb
+++ b/spec/support/generators_shared_examples.rb
@@ -12,8 +12,8 @@ shared_examples "a generator" do
 
   let(:gen) { generator %w[Yummy::Bacon Yummy::BaconTransition] }
 
-  it "invokes create_model_file method" do
-    expect(gen).to receive(:create_model_file)
+  it "invokes create_migration_file method" do
+    expect(gen).to receive(:create_migration_file)
     gen.invoke_all
   end
 


### PR DESCRIPTION
Fixes #460, #546

Namespaced models were not having their transition class generated correctly

Also fixes issue where the model is created after the migration.

Output:

```ruby
# 20250905103710_create_game_chess_transitions.rb
class CreateGameChessTransitions < ActiveRecord::Migration[8.0]
  def change
    create_table :game_chess_transitions do |t|
      t.string :from_state, null: false
      t.string :to_state, null: false
      t.jsonb :metadata, default: {}
      t.integer :sort_key, null: false
      t.integer :game_chess_id, null: false
      t.boolean :most_recent, null: false

      # If you decide not to include an updated timestamp column in your transition
      # table, you'll need to configure the `updated_timestamp_column` setting in your
      # migration class.
      t.timestamps null: false
    end

    # Foreign keys are optional, but highly recommended
    add_foreign_key :game_chess_transitions, :game_chesses

    add_index(:game_chess_transitions,
              %i[game_chess_id sort_key],
              unique: true,
              name: "index_game_chess_transitions_parent_sort")
    add_index(:game_chess_transitions,
              %i[game_chess_id most_recent],
              unique: true,
              where: "most_recent",
              name: "index_game_chess_transitions_parent_most_recent")
  end
end
```
