### PR TITLE
Get test matrix up to date

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
       matrix:
         ruby-version: ["3.2", "3.3", "3.4", "4.0"]
         rails-version:
-          - "7.1"
           - "7.2"
           - "8.0"
           - "8.1"
@@ -55,7 +54,6 @@ jobs:
       matrix:
         ruby-version: ["3.2", "3.3", "3.4", "4.0"]
         rails-version:
-          - "7.1"
           - "7.2"
           - "8.0"
           - "8.1"
@@ -100,7 +98,6 @@ jobs:
       matrix:
         ruby-version: ["3.2", "3.3", "3.4", "4.0"]
         rails-version:
-          - "7.1"
           - "7.2"
           - "8.0"
           - "8.1"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.2", "3.3", "3.4", "3.5"]
+        ruby-version: ["3.2", "3.3", "3.4"]
         rails-version:
           - "7.1"
           - "7.2"
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.2", "3.3", "3.4", "3.5"]
+        ruby-version: ["3.2", "3.3", "3.4"]
         rails-version:
           - "7.1"
           - "7.2"
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.2", "3.3", "3.4", "3.5"]
+        ruby-version: ["3.2", "3.3", "3.4"]
         rails-version:
           - "7.1"
           - "7.2"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,9 @@ jobs:
           - "7.2"
           - "8.0"
           - "main"
+        exclude:
+          - ruby-version: "3.2"
+            rails-version: "main"
     runs-on: ubuntu-latest
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}
@@ -56,6 +59,9 @@ jobs:
           - "8.0"
           - "main"
         postgres-version: ["14", "15", "16", "17"]
+        exclude:
+          - ruby-version: "3.2"
+            rails-version: "main"
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -97,6 +103,9 @@ jobs:
           - "8.0"
           - "main"
         mysql-version: ["8.0", "8.4", "9.4"]
+        exclude:
+          - ruby-version: "3.2"
+            rails-version: "main"
 
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,7 @@ jobs:
           - "7.1"
           - "7.2"
           - "8.0"
+          - "8.1"
           - "main"
         exclude:
           - ruby-version: "3.2"
@@ -57,6 +58,7 @@ jobs:
           - "7.1"
           - "7.2"
           - "8.0"
+          - "8.1"
           - "main"
         postgres-version: ["14", "15", "16", "17"]
         exclude:
@@ -101,6 +103,7 @@ jobs:
           - "7.1"
           - "7.2"
           - "8.0"
+          - "8.1"
           - "main"
         mysql-version: ["8.0", "8.4", "9.4"]
         exclude:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.2", "3.3", "3.4"]
+        ruby-version: ["3.2", "3.3", "3.4", "4.0"]
         rails-version:
           - "7.1"
           - "7.2"
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.2", "3.3", "3.4"]
+        ruby-version: ["3.2", "3.3", "3.4", "4.0"]
         rails-version:
           - "7.1"
           - "7.2"
@@ -90,7 +90,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ["3.2", "3.3", "3.4"]
+        ruby-version: ["3.2", "3.3", "3.4", "4.0"]
         rails-version:
           - "7.1"
           - "7.2"

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ end
 
 group :development, :test do
   gem "ammeter", "~> 1.1"
-  gem "bundler", "~> 2"
   gem "gc_ruboconfig", "~> 5.0.0"
   gem "mysql2", ">= 0.4", "< 0.6"
   gem "pg", ">= 0.18", "<= 1.7"


### PR DESCRIPTION
3.5-preview hasn't had a release since April 2025, and I suspect won't be released

https://www.ruby-lang.org/en/downloads/releases/

In any case, having this pre-release version is blocking upgrades to sqlite3: https://github.com/gocardless/statesman/actions/runs/20566094014/job/59064554664?pr=559