### PR TITLE
Expose the transitioning object on GuardFailedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v13.2.0 29th July 2026
+
+### Added
+
+- Expose the transitioning object on `GuardFailedError` via `#object` [#566](https://github.com/gocardless/statesman/pull/566)
+
 ## v13.1.0 9th October 2025
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -539,6 +539,16 @@ Raised if:
 
 - A guard callback between `from` and `to` state returned a falsey value.
 
+The model object that failed to transition is available via `object`:
+
+```ruby
+begin
+  my_model.transition_to!(:some_state)
+rescue Statesman::GuardFailedError => e
+  logger.error("Guard failed for #{e.object.class}##{e.object.id}: #{e.message}")
+end
+```
+
 #### TransitionFailedError
 
 Raised if:

--- a/lib/statesman/exceptions.rb
+++ b/lib/statesman/exceptions.rb
@@ -30,15 +30,16 @@ module Statesman
   end
 
   class GuardFailedError < StandardError
-    def initialize(from, to, callback)
+    def initialize(from, to, callback, object = nil)
       @from = from
       @to = to
       @callback = callback
+      @object = object
       super(_message)
       set_backtrace(callback.source_location.join(":")) if callback&.source_location
     end
 
-    attr_reader :from, :to, :callback
+    attr_reader :from, :to, :callback, :object
 
     private
 

--- a/lib/statesman/guard.rb
+++ b/lib/statesman/guard.rb
@@ -5,8 +5,8 @@ require_relative "exceptions"
 
 module Statesman
   class Guard < Callback
-    def call(*args)
-      raise GuardFailedError.new(from, to, callback) unless super
+    def call(object = nil, last_transition = nil, metadata = nil)
+      raise GuardFailedError.new(from, to, callback, object) unless super
     end
   end
 end

--- a/lib/statesman/version.rb
+++ b/lib/statesman/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Statesman
-  VERSION = "13.1.0"
+  VERSION = "13.2.0"
 end

--- a/spec/statesman/exceptions_spec.rb
+++ b/spec/statesman/exceptions_spec.rb
@@ -84,8 +84,18 @@ describe "Exceptions" do
       is_expected.to eq([callback.source_location.join(":")])
     end
 
+    its(:object) { is_expected.to be_nil }
+
     its "string matches its message" do
       expect(error.to_s).to eq(error.message)
+    end
+
+    context "when an object is passed" do
+      subject(:error) { Statesman::GuardFailedError.new("from", "to", callback, object) }
+
+      let(:object) { Object.new }
+
+      its(:object) { is_expected.to eq(object) }
     end
   end
 

--- a/spec/statesman/guard_spec.rb
+++ b/spec/statesman/guard_spec.rb
@@ -10,15 +10,27 @@ describe Statesman::Guard do
     subject(:call) { guard.call }
 
     context "success" do
-      let(:callback) { -> { true } }
+      let(:callback) { ->(*) { true } }
 
       specify { expect { call }.to_not raise_error }
     end
 
     context "error" do
-      let(:callback) { -> { false } }
+      let(:callback) { ->(*) { false } }
 
       specify { expect { call }.to raise_error(Statesman::GuardFailedError) }
+
+      context "when called with an object" do
+        subject(:call) { guard.call(object) }
+
+        let(:object) { Object.new }
+
+        specify do
+          expect { call }.to raise_error(
+            an_instance_of(Statesman::GuardFailedError).and(having_attributes(object: object)),
+          )
+        end
+      end
     end
   end
 end

--- a/spec/statesman/machine_spec.rb
+++ b/spec/statesman/machine_spec.rb
@@ -966,7 +966,7 @@ describe Statesman::Machine do
             expect { instance.transition_to!(:y) }.
               to raise_error(
                 an_instance_of(Statesman::GuardFailedError).
-                and(having_attributes(from: "x", to: ["y"])),
+                and(having_attributes(from: "x", to: ["y"], object: my_model)),
               )
           end
         end


### PR DESCRIPTION
## Summary
- `Statesman::GuardFailedError` previously carried no reference to the object being transitioned, making it hard for callers to attach useful context (e.g. resource id/type) to error reports (Sentry, logs).
- `Guard#call` now passes the transitioning object through to `GuardFailedError.new`, and the error exposes it via a new `object` reader.
- The failure message itself is left unchanged (`"Guard on transition from: 'x' to 'y' returned false"`) — deliberately not interpolating the object into the message, since that would fragment Sentrygrouping (which keys off the message) and risks calling `#id` on an arbitrary caller-supplied object.
- README updated with an example of using `object` to attach resource context when notifying an error tracker.

## Test plan
- [x] `bundle exec rspec`
- [x] `bundle exec rubocop` 